### PR TITLE
fix+perf: 修复崩溃与无划线问题，并优化低内存墨水屏的注入与同步

### DIFF
--- a/pickthought.koplugin/main.lua
+++ b/pickthought.koplugin/main.lua
@@ -112,10 +112,17 @@ end
 function Plugin:reader_menu()
     local items={}
     items[#items+1]=self:_sync_status_item()
-    items[#items+1]={text="绑定微信读书",callback=self:safe("bind",function() self:bind_book() end)}
     items[#items+1]={text="同步划线与想法",callback=self:safe("sync_thoughts",function() self:sync_thoughts() end)}
     local doc_path=self:current_doc_path()
-    local doc_bound=doc_path and Binding.get(self.store,doc_path)
+    -- 已绑:直达管理页(少一层弹窗嵌套);未绑:进入绑定流程。
+    local doc_bound_records=doc_path and Binding.list(self.store,doc_path) or {}
+    local doc_bound=#doc_bound_records>0 and doc_bound_records[#doc_bound_records] or nil
+    if #doc_bound_records>0 then
+        items[#items+1]={text=string.format("管理绑定（已绑 %d 本）",#doc_bound_records),
+            callback=self:safe("manage_bind",function() self:_bindings_manage(doc_path) end)}
+    else
+        items[#items+1]={text="绑定微信读书",callback=self:safe("bind",function() self:bind_book() end)}
+    end
     if doc_bound then
         local state=self:_sync_state(doc_bound.book_id)
         if state and (tonumber(state.pending) or 0)>0 then
@@ -191,8 +198,14 @@ function Plugin:book_actions(path)
     if bound or U.file_exists(path..".orig") then
         rows[#rows+1]={{text="重置本书(清数据+还原原版)",callback=act(function() self:reset_book_data(path) end)}}
     end
-    rows[#rows+1]={{text=bound and "重新绑定微信读书" or "绑定微信读书",
-        callback=act(function() self:bind_book(path) end)}}
+    if bound then
+        local n=#Binding.list(self.store,path)
+        rows[#rows+1]={{text=string.format("管理绑定（已绑 %d 本）",n),
+            callback=act(function() self:_bindings_manage(path) end)}}
+    else
+        rows[#rows+1]={{text="绑定微信读书",
+            callback=act(function() self:bind_book(path) end)}}
+    end
     rows[#rows+1]={{text="取消",callback=function() UIManager:close(dialog) end}}
     local title=self:doc_title_guess(path)
     if bound then title=title.."\n已绑定:"..tostring(bound.title or bound.book_id) end
@@ -219,28 +232,109 @@ end
 function Plugin:bind_book(path,on_bound)
     path=path or self:current_doc_path()
     if not path then self:info("请先打开一本本地书") return end
-    local current=Binding.get(self.store,path)
-    if not current then self:bind_search(path,on_bound) return end
+    local records=Binding.list(self.store,path)
+    if #records==0 then self:bind_search(path,on_bound) return end
     local ButtonDialog=require("ui/widget/buttondialog")
-    local display=tostring(current.title or current.book_id or "")
-    if tostring(current.author or "")~="" then display=display.." · "..tostring(current.author) end
+    -- 最近绑定(末尾)作主绑定展示。
+    local primary=records[#records]
+    local display=tostring(primary.title or primary.book_id or "")
+    if tostring(primary.author or "")~="" then display=display.." · "..tostring(primary.author) end
+    local title_text
+    if #records==1 then title_text="当前绑定:\n"..display
+    else title_text=string.format("已绑定 %d 本微信读书书(合集/套装):\n%s\n(+ 其余 %d 本)",#records,display,#records-1) end
     local dialog
     dialog=ButtonDialog:new{
-        title="当前绑定:\n"..display,
+        title=title_text,
         buttons={
-            {{text="重新绑定",callback=function() UIManager:close(dialog); self:bind_search(path,on_bound) end}},
-            {{text="解除绑定",callback=function() UIManager:close(dialog); Binding.clear(self.store,path); self:toast("已解除绑定") end}},
+            {{text="添加另一本书",callback=function() UIManager:close(dialog); self:bind_search(path,on_bound) end}},
+            {{text="管理绑定",callback=function() UIManager:close(dialog); self:_bindings_manage(path,on_bound) end}},
             {{text="取消",callback=function() UIManager:close(dialog) end}},
         },
     }
     UIManager:show(dialog)
 end
 
-function Plugin:bind_search(path,on_bound)
+-- 多书绑定管理:逐本列出,每本提供「换绑」与「解绑」两个独立动作,无需全解再重绑。
+-- 关键:KOReader 的 ButtonDialog 在按钮点击后【不会自动关闭】(见 buttondialog.lua/buttontable.lua:
+-- 按钮仅调用 callback,不关闭对话框)。因此本页打开时拍下的 records 快照会一直停留,任何变更
+-- 操作都必须显式 关闭→重建 本对话框(refresh) 才能刷新列表,否则出现"新绑定不显示 / 解除全部
+-- 后列表不变"等陈旧问题。
+--   换绑 = 先解除该书绑定并立即跳搜索选替换本(其余绑定保留);
+--   解绑 = 仅移除该书(其余绑定保留;本书重新同步即可恢复其想法)。
+function Plugin:_bindings_manage(path,on_bound)
+    local records=Binding.list(self.store,path)
+    local dialog  -- 当前管理页对话框,供 refresh 关闭
+    -- 关闭当前管理页并按最新数据重建(= 列表刷新)。dialog 为 nil 时(0 绑定分支)仅重建。
+    local function refresh()
+        if dialog then UIManager:close(dialog) end
+        self:_bindings_manage(path,on_bound)
+    end
+    if #records==0 then
+        -- 无绑定时直接进入搜索;成功后重开管理页(显示这本新绑定的书),
+        -- 取消则不回调(避免 0 记录下 refresh 反复重入搜索的死循环)。
+        self:bind_search(path,function() self:_bindings_manage(path,on_bound) end,nil)
+        return
+    end
+    local ButtonDialog=require("ui/widget/buttondialog")
+    local rows={}
+    for i,rec in ipairs(records) do
+        local label=tostring(rec.title or rec.book_id or "")
+        if tostring(rec.author or "")~="" then label=label.." · "..tostring(rec.author) end
+        if i==#records then label=label.."（主绑定）" end
+        local bid=tostring(rec.book_id)
+        -- 标题格无 callback,仅作行标签(不可点);右侧两格为动作按钮。
+        rows[#rows+1]={
+            {text=label},
+            {text="换绑",callback=function()
+                UIManager:show(ConfirmBox:new{
+                    text="解除《"..tostring(rec.title or rec.book_id).."》的绑定,并立即搜索新的微信读书书替换?\n其余绑定保留。",
+                    ok_text="换绑",
+                    ok_callback=function()
+                        Binding.remove(self.store,path,bid)
+                        self:toast("已解除,请选择替换本")
+                        if dialog then UIManager:close(dialog) end
+                        self:bind_search(path,refresh,refresh)
+                    end,
+                    cancel_text="取消",
+                })
+            end},
+            {text="解绑",callback=function()
+                UIManager:show(ConfirmBox:new{
+                    text="移除《"..tostring(rec.title or rec.book_id).."》的绑定?\n其余绑定保留;本书重新同步即可恢复其想法。",
+                    ok_text="移除绑定",
+                    ok_callback=function()
+                        Binding.remove(self.store,path,bid)
+                        self:toast("已移除该绑定")
+                        refresh()
+                    end,
+                    cancel_text="返回",
+                })
+            end},
+        }
+    end
+    rows[#rows+1]={{text="添加另一本书",callback=function() self:bind_search(path,refresh,refresh) end}}
+    rows[#rows+1]={{text="解除全部绑定",callback=function()
+        UIManager:show(ConfirmBox:new{
+            text="解除本书的全部微信读书绑定?\n(想法缓存保留,重新绑定可恢复)",
+            ok_text="解除全部",
+            ok_callback=function()
+                Binding.clear(self.store,path)
+                self:toast("已解除全部绑定")
+                refresh()
+            end,
+            cancel_text="取消",
+        })
+    end}}
+    rows[#rows+1]={{text="取消",callback=function() if dialog then UIManager:close(dialog) end end}}
+    dialog=ButtonDialog:new{title="管理绑定",buttons=rows}
+    UIManager:show(dialog)
+end
+
+function Plugin:bind_search(path,on_bound,on_cancel)
     if not self:require_login() then return end
     local d
     d=InputDialog:new{title="搜索微信读书",input=self:doc_title_guess(path),buttons={{
-        {text="取消",id="close",callback=function() UIManager:close(d) end},
+        {text="取消",id="close",callback=function() UIManager:close(d); if on_cancel then on_cancel() end end},
         {text="搜索",is_enter_default=true,callback=function()
             local q=U.trim(d:getInputText()); UIManager:close(d)
             if q=="" then self:info("请输入书名") return end
@@ -506,10 +600,13 @@ function Plugin:sync_entry(path,mode,opts)
 end
 
 function Plugin:_has_reinject_cache(path)
-    local bound=path and Binding.get(self.store,path)
-    if not bound then return false end
-    -- 有 chapters.json 就说明至少完成过一批,离线重注即可用(分批未完也算)。
-    return U.file_exists(self.store:book_cache_path(bound.book_id).."/sync-cache/chapters.json")
+    local records=path and Binding.list(self.store,path) or {}
+    if #records==0 then return false end
+    -- 任一绑定书有 chapters.json 即说明至少完成过一批,离线重注即可用(分批未完也算)。
+    for _,rec in ipairs(records) do
+        if U.file_exists(self.store:book_cache_path(rec.book_id).."/sync-cache/chapters.json") then return true end
+    end
+    return false
 end
 
 -- 读同步进度状态(child 写的 state.json);60s 内存缓存,翻页检查零成本。
@@ -546,7 +643,7 @@ end
 -- ===== 后台同步任务运行时 =====
 function Plugin:_persist_sync_state(runtime)
     self.store:set("sync_runtime",{
-        status="active",doc_path=runtime.doc_path,book_id=runtime.book_id,title=runtime.title,
+        status="active",doc_path=runtime.doc_path,book_id=runtime.book_id,book_ids=runtime.book_ids,title=runtime.title,
         task=runtime.task,started_at=runtime.started_at,
     })
 end
@@ -555,10 +652,15 @@ function Plugin:_clear_sync_state() self.store:set("sync_runtime",{}) end
 
 function Plugin:_start_sync_task(path,bound,mode,opts)
     opts=opts or {}
-    local title=U.trim(tostring(bound.title or ""))
+    local title=U.trim(tostring(bound and bound.title or ""))
     if title=="" then title=self:doc_title_guess(path) end
-    local runtime={doc_path=path,book_id=bound.book_id,title=title,mode=mode,started_at=os.time(),dialog=nil,background=false}
-    local ok,err=self.sync_task:start({doc_path=path,book_id=bound.book_id,title=title,mode=mode},
+    -- 聚合该本地书绑定的全部微信读书书(合集/套装场景),一次同步合并注入。
+    local book_ids={}
+    local records=Binding.list(self.store,path)
+    for _,rec in ipairs(records) do book_ids[#book_ids+1]=tostring(rec.book_id) end
+    if #book_ids==0 then book_ids={tostring(bound and bound.book_id or "")} end
+    local runtime={doc_path=path,book_id=bound and bound.book_id or book_ids[1],book_ids=book_ids,title=title,mode=mode,started_at=os.time(),dialog=nil,background=false}
+    local ok,err=self.sync_task:start({doc_path=path,book_id=runtime.book_id,title=title,mode=mode,book_ids=book_ids},
         function(state) self:_on_sync_progress(runtime,state) end,
         function(result) self:_finish_sync(runtime,result) end)
     if not ok then
@@ -805,7 +907,7 @@ function Plugin:_recover_sync_state()
         self.sync_task:clear_stale_awake()
         return
     end
-    local runtime={doc_path=state.doc_path,book_id=state.book_id,title=state.title,
+    local runtime={doc_path=state.doc_path,book_id=state.book_id,book_ids=state.book_ids,title=state.title,
         started_at=state.started_at,task=state.task,dialog=nil,background=true}
     self._sync_runtime=runtime
     local ok,err=self.sync_task:attach(state.task,
@@ -836,6 +938,11 @@ function Plugin:_sync_run(path,bound)
     local EpubReader=require("pickthought.epub_reader")
     local EpubInject=require("pickthought.epub_inject")
     local WebFetch=require("pickthought.web_fetch")
+    -- 多书绑定:聚合全部绑定书,一次同步合并注入(前台回退路径与后台子进程保持一致)。
+    local book_ids={}
+    local records=Binding.list(self.store,path)
+    for _,rec in ipairs(records) do book_ids[#book_ids+1]=tostring(rec.book_id) end
+    if #book_ids==0 then book_ids={tostring(bound and bound.book_id or "")} end
     if not Trapper:info("正在读取本地书…") then return end
     -- Sync.run 内部对 api/fetch 已 pcall,但 ChapterMap/EpubReader 的意外异常
     -- 会死在协程里(Trapper 只记日志),必须在这里收敛成用户可见的失败。
@@ -843,6 +950,7 @@ function Plugin:_sync_run(path,bound)
         return Sync.run{
             doc_path=path,
             book_id=bound.book_id,
+            book_ids=book_ids,
             api=self.api,
             annotations=WebFetch:new(self.api),
             load_meta=function(p) return EpubReader.load(p) end,
@@ -850,7 +958,8 @@ function Plugin:_sync_run(path,bound)
             read_spine=function(m,callback) return EpubReader.each_spine(m,callback) end,
             save_thoughts=function(book_id,uid,groups) return Thoughts.save(self.store,book_id,uid,groups) end,
             merge_thoughts=function(book_id,uid,from,into) return Thoughts.merge(self.store,book_id,uid,from,into) end,
-            map_cache_path=self.store:book_dir(bound.book_id).."/sync-cache/map.json",
+            -- 多书:每本书独立 map 缓存;单书退化为原文件。
+            map_cache_path=function(bid) return self.store:book_dir(bid).."/sync-cache/map.json" end,
             inject=function(src,book_id,mapped,dest,options)
                 return EpubInject.inject_copy(src,book_id,mapped,
                     {dest=dest,append=options and options.append==true,
@@ -954,13 +1063,18 @@ local RESET_TARGETS = {"sync-cache", "thoughts", "thoughts.db", "thoughts.db-wal
 function Plugin:reset_book_data(path)
     path = path or self:current_doc_path()
     if not path then self:info("请先选择一本书"); return end
-    local bound = Binding.get(self.store, path)
+    local records = Binding.list(self.store, path)
     local has_orig = U.file_exists(path..".orig")
-    if not bound and not has_orig then self:info("这本书无撷思数据,也无原书备份"); return end
+    if #records==0 and not has_orig then self:info("这本书无撷思数据,也无原书备份"); return end
     local title = self:doc_title_guess(path)
-    local book_dir = bound and self.store:book_dir(bound.book_id) or nil
+    -- 多书绑定:清全部绑定书的缓存目录,但保留所有绑定关系。
+    local book_dirs = {}
+    for _, rec in ipairs(records) do book_dirs[#book_dirs+1] = self.store:book_dir(rec.book_id) end
     local lines = {}
-    if book_dir then lines[#lines+1] = "• 清同步缓存/想法数据库/章节映射" end
+    if #book_dirs>0 then
+        if #book_dirs==1 then lines[#lines+1] = "• 清同步缓存/想法数据库/章节映射"
+        else lines[#lines+1] = string.format("• 清 %d 本绑定书的同步缓存/想法数据库/章节映射", #book_dirs) end
+    end
     if has_orig then lines[#lines+1] = "• 还原原书(移除书内划线)" end
     UIManager:show(ConfirmBox:new{
         text = string.format("将重置《%s》:\n\n%s\n\n保留绑定关系,重新同步即可恢复。", title, table.concat(lines, "\n")),
@@ -970,7 +1084,7 @@ function Plugin:reset_book_data(path)
                 text = "再次确认:重置《"..title.."》?\n此操作不可撤销。",
                 ok_text = "确认重置",
                 ok_callback = function()
-                    self:_do_reset_book_data(book_dir, path, title)
+                    self:_do_reset_book_data(book_dirs, path, title)
                 end,
                 cancel_text = "取消",
             })
@@ -1007,10 +1121,10 @@ function Plugin:_restore_original_file(path)
     return ok == true
 end
 
-function Plugin:_do_reset_book_data(book_dir, path, title)
+function Plugin:_do_reset_book_data(book_dirs, path, title)
     local cleared, size_bytes = 0, 0
-    if book_dir then
-        size_bytes = self:_dir_size(book_dir)
+    for _, book_dir in ipairs(book_dirs or {}) do
+        size_bytes = size_bytes + self:_dir_size(book_dir)
         for _, name in ipairs(RESET_TARGETS) do
             if U.remove_tree(book_dir .. "/" .. name) then cleared = cleared + 1 end
         end
@@ -1142,6 +1256,8 @@ end
 
 function Plugin:_show_thought_href(href)
     local info=Thoughts.parse_href(href); if not info then return false end
+    -- 记录当前书,供 onCloseDocument 释放其 SQLite 句柄(KPW3 内存护栏)。
+    self._active_book_id = info.book_id
     if self._thought_popup_busy then return true end
     self._thought_popup_busy=true
     local started=os.clock()
@@ -1190,6 +1306,11 @@ end
 
 function Plugin:onCloseDocument()
     self:_teardown_thought_tap()
+    -- 关闭当前书的想法库句柄,释放 SQLite + WAL(KPW3 阅读期防句柄累积)。
+    if self._active_book_id then
+        pcall(Thoughts.close_book, Thoughts, self.store, self._active_book_id)
+        self._active_book_id = nil
+    end
 end
 
 function Plugin:onFlushSettings() self.store:flush() end

--- a/pickthought.koplugin/pickthought/annotation_style.lua
+++ b/pickthought.koplugin/pickthought/annotation_style.lua
@@ -15,12 +15,9 @@ M.CSS = [[
     text-decoration: none;
     color: inherit;
 }
-.pickthought-link .pickthought-mark {
-    color: inherit;
-}
 .pickthought-mark {
-    border-bottom: 2px dashed #ff6b35;
-    padding-bottom: 2px;
+    text-decoration: underline;
+    color: #ff6b35;
 }
 /* MIUREAD_ANNOTATION_STYLE_V2_END */
 ]]
@@ -198,14 +195,14 @@ function M.xhtml_is_current(html)
     if not html:find("data-pickthought-book=", 1, true) then return true end
     return html:find('id="' .. M.INLINE_STYLE_ID .. '"', 1, true) ~= nil
         and html:find(M.MARKER_BEGIN, 1, true) ~= nil
-        and html:find("border-bottom: 2px dashed #ff6b35;", 1, true) ~= nil
+        and html:find("color: #ff6b35;", 1, true) ~= nil
 end
 
 function M.css_is_current(css)
     css = tostring(css or "")
     return css:find(M.MARKER_BEGIN, 1, true) ~= nil
         and css:find(".pickthought-mark", 1, true) ~= nil
-        and css:find("border-bottom: 2px dashed #ff6b35;", 1, true) ~= nil
+        and css:find("color: #ff6b35;", 1, true) ~= nil
         and css:find(".pickthought-inline-mark.pickthought-has-thought", 1, true) == nil
         and css:find(".pickthought-link .pickthought-inline-mark", 1, true) == nil
 end

--- a/pickthought.koplugin/pickthought/annotations.lua
+++ b/pickthought.koplugin/pickthought/annotations.lua
@@ -319,7 +319,8 @@ local function intervals(data, visible_count, index)
             local survivor = clean[#clean]
             if it.thought and survivor then
                 survivor.thought = true
-                merged[#merged + 1] = {from = it.key, into = survivor.key}
+                -- 带 book_id:多书合并注入时,from→into 的想法并进需定位到正确的书。
+                merged[#merged + 1] = {from = it.key, into = survivor.key, book_id = data.book_id}
             end
         end
     end
@@ -354,9 +355,12 @@ local function render_text_token(token, marks, data)
                     out[#out + 1] = '<a class="pickthought-link" href="' .. href .. '">'
                     thought_link_open = true
                 end
-                local mark_class = Thoughts.mark_class(active.key)
                 local display_class = active.thought and "pickthought-mark" or "pickthought-inline-mark"
-                out[#out + 1] = '<span class="' .. display_class .. ' ' .. mark_class .. '" data-pickthought-range="' .. active.key .. '">'
+                -- 注意: 不追加 Thoughts.mark_class 生成的唯一 class(pickthought-mark-<hex>)。
+                -- 该 class 仅被生成、从不被 CSS/代码读取,却会让 CRE 为每个标注各建一份
+                -- 无法合并的样式,在多书合集(数千标注)下撑爆样式数据存储池导致 KPW3 段错误。
+                -- 唯一标识已由 data-pickthought-range 与 href 承载,去掉它样式零变化、功能不受影响。
+                out[#out + 1] = '<span class="' .. display_class .. '" data-pickthought-range="' .. active.key .. '">'
             end
         end
         out[#out + 1] = unit

--- a/pickthought.koplugin/pickthought/annotations.lua
+++ b/pickthought.koplugin/pickthought/annotations.lua
@@ -335,8 +335,11 @@ local function render_text_token(token, marks, data)
     local active, thought_link_open = nil, false
     local function close_active()
         if not active then return end
-        out[#out + 1] = "</span>"
-        if thought_link_open then out[#out + 1] = "</a>" end
+        if thought_link_open then
+            out[#out + 1] = "</a>"    -- 折叠:单 <a> 承载链接+标注,无内层 <span>
+        else
+            out[#out + 1] = "</span>" -- 仅 <span>(无想法 / 处于既有链接内)
+        end
         active = nil
         thought_link_open = false
     end
@@ -349,18 +352,23 @@ local function render_text_token(token, marks, data)
             if active then
                 -- HTML does not allow links inside links. When an underline overlaps
                 -- an existing footnote/noteref link, preserve the underline style but
-                -- leave the original link as the only clickable target.
+                -- leave the original link as the only clickable target(仍用独立 <span>)。
                 if active.thought and not token.inside_anchor then
+                    -- 折叠:把「链接 <a> + 标注 <span>」合并为单个 <a class="pickthought-link pickthought-mark">,
+                    -- 减半样式元素数量;配合 annotation_style 把 border-bottom 虚线改为 text-decoration,
+                    -- 规避 CRE 样式数据缓存被大量边框元素撑爆导致 KPW3 开书崩溃。
                     local href = Thoughts.href(data.book_id, data.chapter_uid, active.key)
-                    out[#out + 1] = '<a class="pickthought-link" href="' .. href .. '">'
+                    out[#out + 1] = '<a class="pickthought-link pickthought-mark" data-pickthought-range="'
+                        .. active.key .. '" href="' .. href .. '">'
                     thought_link_open = true
+                else
+                    local display_class = active.thought and "pickthought-mark" or "pickthought-inline-mark"
+                    -- 注意: 不追加 Thoughts.mark_class 生成的唯一 class(pickthought-mark-<hex>)。
+                    -- 该 class 仅被生成、从不被 CSS/代码读取,却会让 CRE 为每个标注各建一份
+                    -- 无法合并的样式,在多书合集(数千标注)下撑爆样式数据存储池导致 KPW3 段错误。
+                    -- 唯一标识已由 data-pickthought-range 与 href 承载,去掉它样式零变化、功能不受影响。
+                    out[#out + 1] = '<span class="' .. display_class .. '" data-pickthought-range="' .. active.key .. '">'
                 end
-                local display_class = active.thought and "pickthought-mark" or "pickthought-inline-mark"
-                -- 注意: 不追加 Thoughts.mark_class 生成的唯一 class(pickthought-mark-<hex>)。
-                -- 该 class 仅被生成、从不被 CSS/代码读取,却会让 CRE 为每个标注各建一份
-                -- 无法合并的样式,在多书合集(数千标注)下撑爆样式数据存储池导致 KPW3 段错误。
-                -- 唯一标识已由 data-pickthought-range 与 href 承载,去掉它样式零变化、功能不受影响。
-                out[#out + 1] = '<span class="' .. display_class .. '" data-pickthought-range="' .. active.key .. '">'
             end
         end
         out[#out + 1] = unit

--- a/pickthought.koplugin/pickthought/api.lua
+++ b/pickthought.koplugin/pickthought/api.lua
@@ -196,8 +196,9 @@ function Api:web_chapter_reviews(id, uid)
 end
 function Api:book(id) return self:call("/book/info", {bookId=tostring(id)}) end
 
--- 章节列表走原版实测过的 web 端点(Cookie 鉴权,响应为书记录嵌套形状
--- {data=[{bookId, updated=[...]}]});网关的 /book/chapterinfo 无历史消费者,
+-- 章节列表走原版实测过的 web 端点(Cookie 鉴权,响应为
+-- {bookId?, synckey?, chapters:[{chapterUid,title,chapterIdx,...}]}
+-- 顶层 chapters 数组,注意不是 data);网关的 /book/chapterinfo 无历史消费者,
 -- 真机返回 HTTP 403,仅保留为兜底。
 function Api:web_chapters(id)
     id = tostring(id or "")

--- a/pickthought.koplugin/pickthought/binding.lua
+++ b/pickthought.koplugin/pickthought/binding.lua
@@ -1,118 +1,221 @@
 -- 本地书 ↔ 微信读书书目的绑定:搜索/章节响应规范化 + 按文档路径持久化。
+--
+-- 绑定模型(2026-08 起支持「一本本地书绑定多本微信读书书」,用于合集/套装 EPUB):
+--   all[doc_path] 是一个 map:{ [book_id] = {book_id, title, author, bound_at} }
+-- 旧版本是单条记录(all[doc_path] = record),读取时自动迁移为单元素 map 并落盘。
+-- 对外保持向后兼容:Binding.get 仍返回「主绑定」(最近绑定的一本)单记录,
+-- 因此单绑定场景与旧代码、旧测试行为完全一致。
+--
 -- store 只需 get(k, default) / set(k, v) 两个方法。
 local Binding = {}
 
 local KEY = "bindings"
 
-local function scalar_str(v)
-    local kind = type(v)
-    if kind == "string" or kind == "number" then return tostring(v) end
-    return ""
+local function is_record(v)
+    return type(v) == "table" and type(v.book_id) == "string" and v.book_id ~= ""
 end
 
-local function rows_of(data, names)
-    if type(data) ~= "table" then return {} end
-    for _, name in ipairs(names) do
-        if type(data[name]) == "table" then return data[name] end
+-- 把存储值规范成 map {[book_id]=record}。旧单键记录在此迁移并落盘(仅迁移时写一次)。
+-- 返回规范后的 map(可能为空表)。
+local function normalize(store, doc_path)
+    local all = store:get(KEY, {})
+    local v = all[tostring(doc_path or "")]
+    if is_record(v) then
+        -- 旧单键格式:迁移为单元素 map。
+        local map = { [v.book_id] = v }
+        all[tostring(doc_path or "")] = map
+        store:set(KEY, all)
+        return map
     end
-    if #data > 0 then return data end
+    if type(v) == "table" then
+        local clean = {}
+        for k, rec in pairs(v) do
+            if is_record(rec) then clean[tostring(rec.book_id or k)] = rec end
+        end
+        return clean
+    end
     return {}
 end
 
-function Binding.normalize_search(data)
-    local out = {}
-    local function format_tag(fmt)
-        fmt = tostring(fmt or "")
-        if fmt == "txt" then return " [网络]"
-        elseif fmt == "epub" then return " [出版]" end
-        return ""
-    end
-    local function add_row(row)
-        if type(row) ~= "table" then return end
-        local info = type(row.bookInfo) == "table" and row.bookInfo or row
-        local book_id = scalar_str(info.bookId or info.book_id)
-        if book_id ~= "" then
-            out[#out + 1] = {
-                book_id = book_id,
-                title = scalar_str(info.title) .. format_tag(info.format),
-                author = scalar_str(info.author),
-            }
-        end
-    end
-    for _, row in ipairs(rows_of(data, {"books", "results", "updated"})) do
-        -- /store/search 真实响应是分组形状:results=[{type=..., books=[{bookInfo=...}]}],
-        -- 分组行自身无 bookId,需要下钻 books(与主菜单同款处理)。
-        if type(row) == "table" and type(row.books) == "table"
-            and scalar_str(row.bookId or row.book_id) == "" then
-            for _, sub in ipairs(row.books) do add_row(sub) end
-        else
-            add_row(row)
-        end
-    end
-    return out
+local function load_all(store)
+    return store:get(KEY, {})
 end
 
-local function chapter_uid_of(row)
-    if type(row) ~= "table" then return "" end
-    return scalar_str(row.chapterUid or row.chapterId or row.uid)
+-- 该本地书绑定的全部书,以 map 形式返回 {[book_id]=record}。
+function Binding.records(store, doc_path)
+    return normalize(store, doc_path)
 end
 
--- 经典章节接口按「书记录」返回:{data=[{bookId=..., updated=[章节...]}]},
--- 记录行没有 chapterUid;按 book_id 选中目标记录后下钻内层数组。
-local function chapter_rows(data, book_id)
-    local rows = rows_of(data, {"data", "updated", "chapters", "chapterInfos"})
-    if #rows == 0 or chapter_uid_of(rows[1]) ~= "" then return rows end
-    local function inner_of(record)
-        if type(record) ~= "table" then return nil end
-        for _, key in ipairs({"updated", "chapterInfos", "chapters"}) do
-            if type(record[key]) == "table" then return record[key] end
-        end
-        return nil
-    end
-    local fallback
-    for _, record in ipairs(rows) do
-        local inner = inner_of(record)
-        if inner then
-            fallback = fallback or inner
-            if book_id and scalar_str(record.bookId) == tostring(book_id) then return inner end
-        end
-    end
-    return fallback or rows
+-- 单本绑定记录,或 nil。
+function Binding.get_record(store, doc_path, book_id)
+    return normalize(store, doc_path)[tostring(book_id or "")]
 end
 
-function Binding.normalize_chapters(data, book_id)
-    local out = {}
-    for index, row in ipairs(chapter_rows(data, book_id)) do
-        local uid = chapter_uid_of(row)
-        if uid ~= "" then
-            out[#out + 1] = {
-                uid = uid,
-                title = scalar_str(row.title),
-                idx = tonumber(row.chapterIdx) or index,
-            }
-        end
-    end
-    table.sort(out, function(a, b) return a.idx < b.idx end)
-    return out
-end
-
+-- 向后兼容:返回「主绑定」单记录(最近 bound_at 的一本)。单绑定场景即那一本。
 function Binding.get(store, doc_path)
-    local all = store:get(KEY, {})
-    return all[tostring(doc_path or "")]
+    local map = normalize(store, doc_path)
+    local primary, primary_at
+    for _, rec in pairs(map) do
+        local at = tonumber(rec.bound_at) or 0
+        if not primary or at > (primary_at or 0) then
+            primary, primary_at = rec, at
+        end
+    end
+    return primary
 end
 
-function Binding.save(store, doc_path, record)
-    local all = store:get(KEY, {})
+-- 该本地书绑定的所有书,数组(按绑定时间升序),供 UI 展示与管理。
+function Binding.list(store, doc_path)
+    local map = normalize(store, doc_path)
+    local out = {}
+    for _, rec in pairs(map) do out[#out + 1] = rec end
+    table.sort(out, function(a, b)
+        return (tonumber(a.bound_at) or 0) < (tonumber(b.bound_at) or 0)
+    end)
+    return out
+end
+
+-- 绑定/更新某一本微信读书书。同名 book_id 覆盖,不同 book_id 并存(1:N)。
+function Binding.add(store, doc_path, record)
     record = record or {}
+    if not is_record(record) then return nil, "record 缺少有效的 book_id" end
     if not record.bound_at then record.bound_at = os.time() end
-    all[tostring(doc_path or "")] = record
+    local all = load_all(store)
+    local map = normalize(store, doc_path)
+    map[tostring(record.book_id)] = record
+    all[tostring(doc_path or "")] = map
+    store:set(KEY, all)
+    return record
+end
+
+-- 兼容旧调用:Binding.save 等价于 add(替换同一 book_id 的绑定)。
+function Binding.save(store, doc_path, record)
+    return Binding.add(store, doc_path, record)
+end
+
+-- 移除某一本绑定;若该本地书再无绑定则清除整条记录。
+function Binding.remove(store, doc_path, book_id)
+    local all = load_all(store)
+    local map = normalize(store, doc_path)
+    map[tostring(book_id or "")] = nil
+    if next(map) then
+        all[tostring(doc_path or "")] = map
+    else
+        all[tostring(doc_path or "")] = nil
+    end
     store:set(KEY, all)
 end
 
+-- 解除该本地书的全部绑定。
 function Binding.clear(store, doc_path)
-    local all = store:get(KEY, {})
+    local all = load_all(store)
     all[tostring(doc_path or "")] = nil
     store:set(KEY, all)
+end
+
+-- 搜索结果归一:支持 books[] / results[].books[] / results[] 直接 / 直接数组 四种形状,
+-- 下钻 bookInfo 或直接字段,数字 id 转字符串;format 标注版本类型(txt=网络/epub=出版)。
+function Binding.normalize_search(data)
+    local out = {}
+    if type(data) ~= "table" then return out end
+    local raws = {}
+    local function collect(arr)
+        if type(arr) ~= "table" then return end
+        for _, item in ipairs(arr) do
+            if type(item) == "table" then
+                if item.bookInfo then raws[#raws + 1] = item.bookInfo end
+                if item.books then collect(item.books) end
+                if not item.bookInfo and item.books == nil and item.bookId ~= nil then
+                    raws[#raws + 1] = item
+                end
+            end
+        end
+    end
+    if data.books then collect(data.books) end
+    if data.results then collect(data.results) end
+    if #raws == 0 then collect(data) end
+    local function suffix(format)
+        if format == "txt" then return " [网络]" end
+        if format == "epub" then return " [出版]" end
+        return ""
+    end
+    for _, raw in ipairs(raws) do
+        local id = raw.bookId
+        if id ~= nil and tostring(id) ~= "" then
+            out[#out + 1] = {
+                book_id = tostring(id),
+                title = tostring(raw.title or "") .. suffix(raw.format),
+                author = tostring(raw.author or ""),
+            }
+        end
+    end
+    return out
+end
+
+-- 章节列表归一:真实 web 端点(/web/book/chapterInfos)返回
+--   {bookId?, synckey?, chapters:[{chapterUid,title,chapterIdx,...}]}
+-- 故优先认 data.chapters;旧文档说的嵌套 {data=[{bookId,updated}]} 仅作兜底。
+-- 无 bookId 选择时 data.data / chapterInfos / updated / 直接数组 皆可用。
+-- 丢弃无 chapterUid 的条目,uid 字符串化,按 chapterIdx 升序排列。
+function Binding.normalize_chapters(data, book_id)
+    local out = {}
+    if type(data) ~= "table" then return out end
+    local book_id_s = book_id ~= nil and tostring(book_id) or nil
+    local source
+    if type(data.chapters) == "table" then
+        source = data.chapters
+    elseif type(data.data) == "table" then
+        local chosen
+        if book_id_s then
+            for _, rec in ipairs(data.data) do
+                if type(rec) == "table" and tostring(rec.bookId or "") == book_id_s then
+                    chosen = rec; break
+                end
+            end
+        end
+        if chosen then
+            -- 命中目标书记录:取其 updated/chapterInfos 内层章节。
+            source = chosen.updated or chosen.chapterInfos or chosen.data
+        else
+            -- data.data 可能是章节数组(无 bookId),也可能是书记录数组但无匹配
+            -- 目标书:无匹配时若首条是书记录则退回其 updated,否则当章节数组处理。
+            local first = data.data[1]
+            if type(first) == "table"
+                and (first.bookId ~= nil or first.updated ~= nil or first.chapterInfos ~= nil) then
+                source = first.updated or first.chapterInfos or first.data
+            else
+                source = data.data
+            end
+        end
+    elseif type(data.chapterInfos) == "table" then
+        source = data.chapterInfos
+    elseif type(data.updated) == "table" then
+        source = data.updated
+    else
+        source = data
+    end
+    local raw = {}
+    if type(source) == "table" then
+        for _, ch in ipairs(source) do raw[#raw + 1] = ch end
+    end
+    local rows = {}
+    for _, ch in ipairs(raw) do
+        if type(ch) == "table" and ch.chapterUid ~= nil then
+            rows[#rows + 1] = {
+                uid = tostring(ch.chapterUid),
+                title = tostring(ch.title or ""),
+                chapterIdx = tonumber(ch.chapterIdx),
+            }
+        end
+    end
+    table.sort(rows, function(a, b)
+        local ai = a.chapterIdx or 0
+        local bi = b.chapterIdx or 0
+        if ai ~= bi then return ai < bi end
+        return a.uid < b.uid
+    end)
+    for _, r in ipairs(rows) do r.chapterIdx = nil end
+    return rows
 end
 
 return Binding

--- a/pickthought.koplugin/pickthought/chapter_map.lua
+++ b/pickthought.koplugin/pickthought/chapter_map.lua
@@ -248,11 +248,12 @@ local function build_with_scanner(spine, chapters, scan)
                     mapped[#mapped + 1] = {
                         chapter_uid = tostring(ch.uid or ""), href = href,
                         underlines = underlines, review_map = ch.review_map or {},
-                        quote_only = quote_only,
+                        quote_only = quote_only, book_id = ch.book_id,
                     }
                 end
             else
-                unmatched[#unmatched + 1] = {uid = tostring(ch.uid or ""), title = ch.title, reason = "no_hit"}
+                unmatched[#unmatched + 1] = {uid = tostring(ch.uid or ""), title = ch.title,
+                    reason = "no_hit", book_id = ch.book_id}
             end
         end
     end

--- a/pickthought.koplugin/pickthought/epub_inject.lua
+++ b/pickthought.koplugin/pickthought/epub_inject.lua
@@ -33,6 +33,10 @@ local GC_MEMORY_SAMPLE_INTERVAL = 8
 local GC_LARGE_ENTRY_BYTES = 2 * 1024 * 1024
 local GC_HEAP_GROWTH_KB = 8 * 1024
 local GC_LOW_MEMORY_KB = 128 * 1024
+-- 非目标条目 ≥ 此大小走磁盘拷贝(extractToPath→临时文件→addPath),不进 Lua 堆,
+-- 灭大图/大字库/多媒体条目的 OOM 尖峰。阈值权衡:太小会为大量小条目增加 SD I/O,
+-- 太大则中等大条目仍驻留堆;512KB 可覆盖绝大多数图片/字体/媒体。
+local DISK_PATH_THRESHOLD = 512 * 1024
 
 local function memory_available_kb()
     local raw = U.read_file("/proc/meminfo", true)
@@ -192,6 +196,8 @@ local function count_marks(rendered, underlines, base)
 end
 
 local function chapter_data(book_id, ch)
+    -- 多书合并注入时,每个 mapped 章节自带 ch.book_id;单书场景回退到入参 book_id。
+    book_id = ch.book_id or book_id
     local underlines = ch.underlines or {}
     local review_map = ch.review_map or {}
     local thought_count = 0
@@ -208,6 +214,26 @@ local function get_archiver(archiver)
     local ok, mod = pcall(require, "ffi/archiver")
     if not ok then return nil, "需要 KOReader v2026.03 或更新版本(缺少 ffi/archiver)" end
     return mod
+end
+
+-- 非目标大条目走磁盘拷贝:extractToPath 抽到临时文件 → addPath 写回,全程不进 Lua 堆,
+-- 灭大图/字库/媒体造成的 OOM 尖峰。失败返回 false,调用方回退内存路径(行为不变)。
+-- 注意 addPath 恒按 entry_root/rel 拼 zip 路径,顶层无斜杠条目(如 mimetype,已单独处理)
+-- 无法用其正确表示,故 first 缺失时直接回退。
+local function copy_entry_via_disk(reader, writer, entry, mtime, disk_tmp_base)
+    local first, rest = tostring(entry.path):match("^([^/]+)/(.*)$")
+    if not first or rest == "" then return false end
+    local sub = disk_tmp_base .. "-e" .. tostring(entry.index)
+    U.mkdir(sub)
+    local ok_ext = reader:extractToPath(entry.path, sub .. "/" .. rest)
+    if not ok_ext then
+        pcall(U.remove_tree, sub)
+        return false
+    end
+    local ok_add = writer:addPath(first, sub, true, mtime)
+    pcall(U.remove_tree, sub)
+    if not ok_add then return false end
+    return true
 end
 
 function M.inject_copy(src, book_id, chapters, opts)
@@ -292,12 +318,17 @@ function M.inject_copy(src, book_id, chapters, opts)
     if not writer:open(tmp, "epub") then
         return nil, "无法创建副本:" .. tostring(writer.err or tmp)
     end
+    -- 非目标大条目走磁盘拷贝的临时根目录:本批同步一个,失败/结束统一清理。
+    disk_tmp = dest .. ".spine-" .. tostring(mtime)
+    U.mkdir(disk_tmp)
 
     local reader
+    local disk_tmp  -- 非目标大条目走磁盘的临时根,失败/结束统一清理
     local function fail(message)
         local detail = writer.err
         writer:close()
         if reader then reader:close() end
+        pcall(U.remove_tree, disk_tmp)
         os.remove(tmp)
         return nil, message .. (detail and ("(" .. detail .. ")") or "")
     end
@@ -341,70 +372,84 @@ function M.inject_copy(src, book_id, chapters, opts)
             seen_entries = seen_entries + 1
             if not written[entry.path] then
                 written[entry.path] = true
-                local content = reader:extractToMemory(entry.path)
-                if not content then
-                    local read_err = reader.err
-                    return fail("无法读取 EPUB 条目:" .. entry.path
-                        .. (read_err and ("(" .. read_err .. ")") or ""))
-                end
                 local rows = groups[entry.path]
-                if rows then
-                    -- 多个微信章节可以落在同一 spine 文件:在前面章节的注入结果上叠加。
-                    local injected_before = false
-                    for _, ch in ipairs(rows) do
-                        local data = chapter_data(book_id, ch)
-                        -- 叠加章节的 range 是微信侧章节内偏移,对合并文件毫无意义:
-                        -- 引文对齐不中就丢弃,绝不允许数字兜底把划线画进别章正文。
-                        -- 拆分章(quote_only,一微信章注入多文件)同理:各文件只收
-                        -- 引文对齐得上的划线,防错位防跨文件重复。
-                        if injected_before or ch.quote_only then data.no_numeric_fallback = true end
-                        local rendered, _, ch_stats = Annotations:new(nil):apply(content, data)
-                        local mark_count, hit_keys = count_marks(rendered, data.underlines, content)
-                        local track = uid_track[data.chapter_uid]
-                        for key in pairs(hit_keys) do track.resolved[key] = true end
-                        for _, key in ipairs(ch_stats.overlapped_keys or {}) do
-                            track.resolved[tostring(key)] = true
-                        end
-                        stats.quote_aligned = stats.quote_aligned + (ch_stats.quote_aligned or 0)
-                        stats.numeric = stats.numeric + (ch_stats.numeric or 0)
-                        stats.dropped = stats.dropped + (ch_stats.dropped or 0)
-                        stats.overlapped = stats.overlapped + (ch_stats.overlapped or 0)
-                        for _, merge in ipairs(ch_stats.merged or {}) do
-                            stats.merges[#stats.merges + 1] = {
-                                uid = data.chapter_uid, from = merge.from, into = merge.into,
-                            }
-                        end
-                        if mark_count > 0 then
-                            content = ensure_style(rendered)
-                            injected_before = true
-                            -- 拆分章会产生同 uid 多行,injected 按「有锚点落书的微信章」去重计数。
-                            if not injected_uids[data.chapter_uid] then
-                                injected_uids[data.chapter_uid] = true
-                                stats.injected = stats.injected + 1
-                            end
-                            stats.marks = stats.marks + mark_count
-                            marker_chapters[#marker_chapters + 1] = {
-                                uid = data.chapter_uid, href = entry.path, marks = mark_count,
-                            }
-                        end
-                    end
-                end
                 local ext = entry.path:match("%.(%w+)$")
                 local want = (not rows) and ext and STORED_EXTS[ext:lower()] and "store" or "deflate"
                 if want ~= compression then
                     writer:setZipCompression(want)
                     compression = want
                 end
-                if not writer:addFileFromMemory(entry.path, content, mtime) then
-                    return fail("写入副本失败:" .. entry.path)
+                -- 非目标且较大(图/字库/媒体)的条目走磁盘拷贝,不进 Lua 堆,灭 OOM 尖峰;
+                -- 目标条目(需改内容)与较小条目走内存快路径。磁盘路径失败一律回退内存。
+                local via_disk
+                if not rows and entry.size and entry.size >= DISK_PATH_THRESHOLD
+                   and entry.path:find("/", 1, true) then
+                    via_disk = copy_entry_via_disk(reader, writer, entry, mtime, disk_tmp)
                 end
-                if opts.progress then pcall(opts.progress, entry.path, seen_entries, total_entries) end
-                local content_bytes = #content
-                content = nil
-                gc_policy:release(content_bytes)
+                if not via_disk then
+                    local content = reader:extractToMemory(entry.path)
+                    if not content then
+                        local read_err = reader.err
+                        return fail("无法读取 EPUB 条目:" .. entry.path
+                            .. (read_err and ("(" .. read_err .. ")") or ""))
+                    end
+                    if rows then
+                        -- 多个微信章节可以落在同一 spine 文件:在前面章节的注入结果上叠加。
+                        local injected_before = false
+                        for _, ch in ipairs(rows) do
+                            local data = chapter_data(book_id, ch)
+                            -- 叠加章节的 range 是微信侧章节内偏移,对合并文件毫无意义:
+                            -- 引文对齐不中就丢弃,绝不允许数字兜底把划线画进别章正文。
+                            -- 拆分章(quote_only,一微信章注入多文件)同理:各文件只收
+                            -- 引文对齐得上的划线,防错位防跨文件重复。
+                            if injected_before or ch.quote_only then data.no_numeric_fallback = true end
+                            local rendered, _, ch_stats = Annotations:new(nil):apply(content, data)
+                            local mark_count, hit_keys = count_marks(rendered, data.underlines, content)
+                            local track = uid_track[data.chapter_uid]
+                            for key in pairs(hit_keys) do track.resolved[key] = true end
+                            for _, key in ipairs(ch_stats.overlapped_keys or {}) do
+                                track.resolved[tostring(key)] = true
+                            end
+                            stats.quote_aligned = stats.quote_aligned + (ch_stats.quote_aligned or 0)
+                            stats.numeric = stats.numeric + (ch_stats.numeric or 0)
+                            stats.dropped = stats.dropped + (ch_stats.dropped or 0)
+                            stats.overlapped = stats.overlapped + (ch_stats.overlapped or 0)
+                            for _, merge in ipairs(ch_stats.merged or {}) do
+                                stats.merges[#stats.merges + 1] = {
+                                    uid = data.chapter_uid, from = merge.from, into = merge.into,
+                                    book_id = merge.book_id or data.book_id,
+                                }
+                            end
+                            if mark_count > 0 then
+                                content = ensure_style(rendered)
+                                injected_before = true
+                                -- 拆分章会产生同 uid 多行,injected 按「有锚点落书的微信章」去重计数。
+                                if not injected_uids[data.chapter_uid] then
+                                    injected_uids[data.chapter_uid] = true
+                                    stats.injected = stats.injected + 1
+                                end
+                                stats.marks = stats.marks + mark_count
+                                marker_chapters[#marker_chapters + 1] = {
+                                    uid = data.chapter_uid, href = entry.path, marks = mark_count,
+                                }
+                            end
+                        end
+                    end
+                    if not writer:addFileFromMemory(entry.path, content, mtime) then
+                        return fail("写入副本失败:" .. entry.path)
+                    end
+                    if opts.progress then pcall(opts.progress, entry.path, seen_entries, total_entries) end
+                    local content_bytes = #content
+                    content = nil
+                    gc_policy:release(content_bytes)
+                else
+                    if opts.progress then pcall(opts.progress, entry.path, seen_entries, total_entries) end
+                    gc_policy:release(entry.size or 0)
+                end
             end
         end
     end
+    U.remove_tree(disk_tmp)
     reader:close()
     reader = nil
 
@@ -424,6 +469,7 @@ function M.inject_copy(src, book_id, chapters, opts)
     end
 
     if stats.injected == 0 then
+        pcall(U.remove_tree, disk_tmp)
         writer:close()
         os.remove(tmp)
         return nil, string.format("没有可注入的章节(未匹配 %d 章,定位失败 %d 条划线)",
@@ -431,9 +477,15 @@ function M.inject_copy(src, book_id, chapters, opts)
     end
 
     if compression ~= "deflate" then writer:setZipCompression("deflate") end
+    -- 多书合并注入时记录 book_ids 列表;单书场景退化为 [book_id]。
+    -- 保留顶层 book_id(首本)字段以兼容旧版读取已注入书的 MARKER。
+    local book_ids = opts.book_ids
+    if type(book_ids) ~= "table" or #book_ids == 0 then
+        book_ids = { tostring(book_id or "") }
+    end
     if not writer:addFileFromMemory(M.MARKER, Json.encode({
-        version = 1, book_id = tostring(book_id or ""), created = mtime,
-        source = src, chapters = marker_chapters,
+        version = 1, book_id = tostring(book_ids[1] or ""), book_ids = book_ids,
+        created = mtime, source = src, chapters = marker_chapters,
     }), mtime) then
         return fail("写入副本失败:" .. M.MARKER)
     end

--- a/pickthought.koplugin/pickthought/spine_cache.lua
+++ b/pickthought.koplugin/pickthought/spine_cache.lua
@@ -1,0 +1,140 @@
+-- spine 正文(原始 HTML)持久化缓存。
+--
+-- 背景:分批同步时,每批只要还有没见过的新章节(todo>0),map 阶段就必须
+-- 把整本书的 spine 文件逐一读一遍,才能给新章节的引文定位(引文可能落在
+-- 任何文件里)。原实现每批都从 EPUB 把每个 spine 文件解压进内存再 normalize,
+-- 慢书 + 低性能设备(FAT32 SD、256MB RAM)上反复解压很费时。
+--
+-- 本缓存把每个 spine 文件的原始 HTML 落盘(与 map.json 同目录),第 2 批起
+-- 直接读缓存文本喂给 ChapterMap,map 阶段不再解压原 EPUB、不再重复 normalize,
+-- 大幅提速。代价:多占 ≈ 书大小 的磁盘(随「重置本书」一并清理)。
+--
+-- 红线安全:缓存的正是 read_text 的原始输出,ChapterMap 照常 normalize
+-- (normalize 幂等),匹配结果与最终注入的 EPUB 字节完全一致;不触碰任何
+-- 匹配逻辑,也不需要改动 ALGO_VERSION。缓存指纹与 map.json 同源(源书大小 @
+-- 算法版本),换书或升算法自动整体作废。
+local U = require("pickthought.util")
+local Json = require("pickthought.json")
+local logger = require("logger")
+
+local SpineCache = {}
+
+-- 指纹形如 "123456@7",目录名里 "@" 换成 "_" 以免歧义。
+local function sig_to_dir(signature)
+    return "spine-" .. tostring(signature):gsub("@", "_")
+end
+
+-- 由 map.json 路径推导 spine 缓存目录(同目录下的 spine-<指纹> 子目录)。
+-- 无 map_cache_path 时返回 nil(调用方未开启缓存)。
+function SpineCache.dir_for(map_cache_path, signature)
+    if not map_cache_path or not signature then return nil end
+    local base = map_cache_path:match("^(.*)/[^/]+$")
+    if not base or base == "" then base = map_cache_path:match("^(.*)\\[^\\]+$") end
+    if not base or base == "" then base = "." end
+    return base .. "/" .. sig_to_dir(signature)
+end
+
+-- 打开缓存:命中(指纹匹配 + manifest 存在)则 warm 模式直接服务;
+-- 否则 cold 模式,首次 put 时建目录并捕获。dir 为 nil 时返回 nil(缓存禁用)。
+function SpineCache.open(dir, signature)
+    if not dir then return nil end
+    local self = {
+        dir = dir,
+        signature = signature,
+        mode = "cold",
+        entries = {},
+        _seq = 1,
+        dir_ready = false,
+        dirty = false,
+    }
+    setmetatable(self, { __index = SpineCache })
+
+    -- 清理同目录下旧指纹遗留的 cache 目录(换书/升算法后旧目录失效,省磁盘)。
+    local parent = dir:match("^(.*)/[^/]+$")
+    if parent and parent ~= "" then
+        local self_name = dir:match("/([^/]+)$")
+        for _, f in ipairs(U.list(parent)) do
+            local name = f:match("/([^/]+)$") or f
+            if name:find("^spine%-") and name ~= self_name then
+                pcall(U.remove_tree, f)
+            end
+        end
+    end
+
+    local manifest_path = dir .. "/manifest.json"
+    if U.file_exists(manifest_path) then
+        local raw = U.read_file(manifest_path, true)
+        if raw then
+            local ok, decoded = pcall(Json.decode, raw)
+            if ok and type(decoded) == "table"
+                and tostring(decoded.signature) == tostring(signature)
+                and type(decoded.entries) == "table" then
+                self.entries = decoded.entries
+                self.mode = "warm"
+            end
+        end
+    end
+    if self.mode == "cold" then
+        -- 清空任何上次中断留下的残缺缓存,从头捕获。
+        pcall(U.remove_tree, dir)
+        self.entries = {}
+    end
+    return self
+end
+
+function SpineCache:warm()
+    return self.mode == "warm"
+end
+
+-- 当前 spine 全部 href 是否都已在缓存里(用于决定是否敢在 read_spine 走暖路径)。
+function SpineCache:covers(spine)
+    if self.mode ~= "warm" then return false end
+    for _, item in ipairs(spine or {}) do
+        local href = type(item) == "table" and item.href or tostring(item)
+        if not self.entries[tostring(href)] then return false end
+    end
+    return true
+end
+
+-- 取缓存正文;缺失返回 nil(调用方据此回退真实读取并补写)。
+function SpineCache:get(href)
+    if self.mode ~= "warm" then return nil end
+    local fname = self.entries[tostring(href)]
+    if not fname then return nil end
+    local data = U.read_file(self.dir .. "/" .. fname, true)
+    if data == nil then return nil end
+    return data
+end
+
+-- 写入一个 spine 文件的原始 HTML。content 为 nil 时忽略(读取失败不缓存)。
+-- 文件名用单调序号 e1/e2/...,href 与文件名的映射记在 entries 里,永不撞名。
+function SpineCache:put(href, content)
+    if content == nil then return end
+    href = tostring(href)
+    local fname = self.entries[href]
+    if not fname then
+        if self.mode == "cold" and not self.dir_ready then
+            U.mkdir(self.dir)
+            self.dir_ready = true
+        end
+        fname = "e" .. tostring(self._seq)
+        self._seq = self._seq + 1
+        self.entries[href] = fname
+    end
+    local ok = pcall(U.atomic_write, self.dir .. "/" .. fname, content, true)
+    if ok then self.dirty = true end
+end
+
+-- 关闭:仅 cold 模式且确有写入时落盘 manifest,供后续批次 warm 命中。
+-- warm 模式 manifest 已完整,无需重写。
+function SpineCache:close()
+    if self.mode == "cold" and self.dirty and self.dir_ready then
+        local count = 0
+        for _ in pairs(self.entries) do count = count + 1 end
+        local manifest = { signature = self.signature, count = count, entries = self.entries }
+        local ok, encoded = pcall(Json.encode, manifest)
+        if ok then pcall(U.atomic_write, self.dir .. "/manifest.json", encoded, true) end
+    end
+end
+
+return SpineCache

--- a/pickthought.koplugin/pickthought/sync.lua
+++ b/pickthought.koplugin/pickthought/sync.lua
@@ -20,9 +20,25 @@ local ChapterMap = require("pickthought.chapter_map")
 local EpubInject = require("pickthought.epub_inject")
 local Json = require("pickthought.json")
 local U = require("pickthought.util")
+local SpineCache = require("pickthought.spine_cache")
 local logger = require("logger")
 
 local Sync = {}
+
+-- 绑定支持「一本本地书绑多本微信读书书」(合集/套装 EPUB)。book_ids 为列表;
+-- 未提供时回退到单个 deps.book_id(旧调用方/旧测试保持原样)。去重保序。
+local function book_ids_of(deps)
+    if type(deps.book_ids) == "table" and #deps.book_ids > 0 then
+        local seen, out = {}, {}
+        for _, b in ipairs(deps.book_ids) do
+            local s = tostring(b or "")
+            if s ~= "" and not seen[s] then seen[s] = true; out[#out + 1] = s end
+        end
+        if #out > 0 then return out end
+    end
+    if deps.book_id then return {tostring(deps.book_id)} end
+    return {}
+end
 
 Sync.BACKUP_SUFFIX = ".orig"
 
@@ -37,11 +53,25 @@ function Sync.run(deps)
     local rename = deps.rename or os.rename
     local remove = deps.remove or os.remove
 
+    -- 绑定支持「一本本地书绑多本微信读书书」。book_ids 为列表;未提供时
+    -- 回退到单个 deps.book_id,旧调用方/旧测试行为不变。
+    local book_ids = book_ids_of(deps)
+    if #book_ids == 0 then return nil, "未指定要同步的微信读书书" end
+    local multi_book = #book_ids > 1
+    -- 多书合并映射的缓存键命名空间(防跨书 uid 撞键);单书退化为纯 uid,缓存格式不变。
+    local function ck(bid, uid) return multi_book and (tostring(bid) .. "/" .. tostring(uid)) or tostring(uid) end
+    -- 映射缓存路径:可传函数(每书独立文件)或字符串(单书单文件,旧行为)。
+    local function cache_path_for(bid)
+        if type(deps.map_cache_path) == "function" then return deps.map_cache_path(bid) end
+        return deps.map_cache_path
+    end
+
     -- 已有注入版时,增量同步直接以当前书为源;首次/全量重建才从 .orig 读取。
+    -- 多书合并注入必须基于干净 .orig 整体重建,不能走增量 append(否则漏书)。
     local doc_path = tostring(deps.doc_path)
     local backup = Sync.backup_path(doc_path)
     local current_meta = deps.load_meta(doc_path)
-    local append = deps.append == true and current_meta and current_meta.has
+    local append = (not multi_book) and deps.append == true and current_meta and current_meta.has
         and current_meta.has[EpubInject.MARKER] == true
     local src = append and doc_path or (file_exists(backup) and backup or doc_path)
 
@@ -65,20 +95,15 @@ function Sync.run(deps)
         end
     end
 
-    if not step("chapters", 0, 1, "获取章节列表") then return nil, "已取消" end
-    local ok, chapters_raw = pcall(function() return deps.api:chapters(deps.book_id) end)
-    if not ok then return nil, "获取章节列表失败:" .. tostring(chapters_raw) end
-    local chapter_list = Binding.normalize_chapters(chapters_raw, deps.book_id)
-    if #chapter_list == 0 then return nil, "微信读书返回的章节列表为空" end
-
+    -- 每本书独立拉取,累积到同一 fetched 列表;每章携带 book_id 供后续
+    -- save_thoughts / 注入 / 想法合并正确定位到对应书。
     local fetched = {}
     local total_underlines = 0
     local total_thought_entries = 0
+    local chapters_total_all = 0
     -- fetch_budget 是网络预算; chapter_budget 是 CPU/注入预算,两者不能混用。
     local fetch_budget = tonumber(deps.fetch_budget)
     if fetch_budget and fetch_budget <= 0 then fetch_budget = nil end
-    local chapter_start = math.max(1, tonumber(deps.chapter_start) or 1)
-    if not append then chapter_start = 1 end
     local chapter_budget = tonumber(deps.chapter_budget)
     if chapter_budget and chapter_budget <= 0 then chapter_budget = nil end
     local skip_resumed = deps.skip_resumed == true
@@ -86,10 +111,9 @@ function Sync.run(deps)
     local chapters_pending = 0
     local rate_limited = false
     local rate_limit_wait
-    local next_index = chapter_start
+    local next_index
     local batch_start_index, batch_end_index
     local chapters_processed, chapters_fetch_succeeded = 0, 0
-    local selected_end = #chapter_list
     -- 硬失败=整章划线都没拉到(决定是否中止);部分失败=划线在手、想法批次有缺(只计报告)。
     local hard_failures, partial_errors = 0, 0
     local thoughts_saved, save_failures = 0, 0
@@ -102,98 +126,126 @@ function Sync.run(deps)
         if #text > 160 then text = text:sub(1, 160) .. "…" end
         return text
     end
-    if not skip_resumed and chapter_budget then
-        selected_end = math.min(#chapter_list, chapter_start + chapter_budget - 1)
-    end
-    local i = chapter_start
-    while i <= #chapter_list do
-        local ch = chapter_list[i]
-        if fetch_budget and fresh_fetches >= fetch_budget then
-            chapters_pending = #chapter_list - i + 1
-            break
-        end
-        if not skip_resumed and i > selected_end then
-            chapters_pending = #chapter_list - i + 1
-            break
-        end
-        if not step("fetch", i, #chapter_list, ch.title) then return nil, "已取消" end
-        local good, data = pcall(function()
-            return deps.annotations:fetch_chapter(deps.book_id, ch.uid)
-        end)
-        -- 预算按"网络请求次数"计:缓存命中(resumed)免费,失败的尝试也占额度。
-        if not (good and type(data) == "table" and data.resumed) then
-            fresh_fetches = fresh_fetches + 1
-        end
-        local chapter_rate_limited = good and type(data) == "table" and data.rate_limited == true
-        local skipped_completed_cache = good and type(data) == "table"
-            and data.resumed and skip_resumed
-        if chapter_rate_limited then
-            rate_limited = true
-            rate_limit_wait = tonumber(data.rate_limit_wait) or rate_limit_wait
-        elseif good and type(data) == "table" and data.resumed and skip_resumed then
-            -- 完整缓存只扫描以寻找新增/缺失章节,不重复写库和重注入旧章节。
-        elseif good and type(data) == "table" and data.underline_request_ok ~= false then
-            -- 断点缓存命中(resumed)不算网络成功,不能复位熔断计数:
-            -- 离线续传时散布的缓存命中会把计数清零,让熔断永不触发。
-            if not data.resumed then consecutive_hard = 0 end
-            if #(data.errors or {}) > 0 then partial_errors = partial_errors + 1 end
-            total_underlines = total_underlines + (data.underline_count or 0)
-            total_thought_entries = total_thought_entries + (data.thought_entry_count or 0)
-            if (data.underline_count or 0) > 0 then
-                fetched[#fetched + 1] = {
-                    uid = ch.uid, title = ch.title,
-                    underlines = data.underlines, review_map = data.review_map,
-                }
+
+    -- 单本书的拉取(含续拉预算/熔断)。多书时每本都从头拉(各书独立续拉暂不支撑)。
+    local function fetch_book(bid)
+        if not step("chapters", 0, 1, "获取章节列表") then return nil, "已取消" end
+        local ok, chapters_raw = pcall(function() return deps.api:chapters(bid) end)
+        if not ok then return nil, "获取章节列表失败:" .. tostring(chapters_raw) end
+        local chapter_list = Binding.normalize_chapters(chapters_raw, bid)
+        chapters_total_all = chapters_total_all + #chapter_list
+        if #chapter_list == 0 then
+            if multi_book then
+                logger.warn("[撷思][Sync] 子书章列表为空,跳过", "book=", tostring(bid))
+                return true
             end
-            if #(data.review_groups or {}) > 0 then
-                local ok_save, saved = pcall(deps.save_thoughts, deps.book_id, ch.uid, data.review_groups)
-                if ok_save and saved then
-                    thoughts_saved = thoughts_saved + 1
-                else
-                    save_failures = save_failures + 1
-                    thought_save_failed[tostring(ch.uid)] = true
+            return nil, "微信读书返回的章节列表为空"
+        end
+        local chapter_start = (not multi_book) and math.max(1, tonumber(deps.chapter_start) or 1) or 1
+        if not append then chapter_start = 1 end
+        local selected_end = #chapter_list
+        if (not multi_book) and (not skip_resumed) and chapter_budget then
+            selected_end = math.min(#chapter_list, chapter_start + chapter_budget - 1)
+        end
+        local i = chapter_start
+        local book_next = chapter_start
+        while i <= #chapter_list do
+            local ch = chapter_list[i]
+            ch.book_id = bid
+            if fetch_budget and fresh_fetches >= fetch_budget then
+                chapters_pending = chapters_pending + (#chapter_list - i + 1)
+                break
+            end
+            if (not multi_book) and (not skip_resumed) and i > selected_end then
+                chapters_pending = chapters_pending + (#chapter_list - i + 1)
+                break
+            end
+            if not step("fetch", i, #chapter_list, ch.title) then return nil, "已取消" end
+            local good, data = pcall(function()
+                return deps.annotations:fetch_chapter(bid, ch.uid)
+            end)
+            -- 预算按"网络请求次数"计:缓存命中(resumed)免费,失败的尝试也占额度。
+            if not (good and type(data) == "table" and data.resumed) then
+                fresh_fetches = fresh_fetches + 1
+            end
+            local chapter_rate_limited = good and type(data) == "table" and data.rate_limited == true
+            local skipped_completed_cache = good and type(data) == "table"
+                and data.resumed and skip_resumed
+            if chapter_rate_limited then
+                rate_limited = true
+                rate_limit_wait = tonumber(data.rate_limit_wait) or rate_limit_wait
+            elseif good and type(data) == "table" and data.resumed and skip_resumed then
+                -- 完整缓存只扫描以寻找新增/缺失章节,不重复写库和重注入旧章节。
+            elseif good and type(data) == "table" and data.underline_request_ok ~= false then
+                -- 断点缓存命中(resumed)不算网络成功,不能复位熔断计数:
+                -- 离线续传时散布的缓存命中会把计数清零,让熔断永不触发。
+                if not data.resumed then consecutive_hard = 0 end
+                if #(data.errors or {}) > 0 then partial_errors = partial_errors + 1 end
+                total_underlines = total_underlines + (data.underline_count or 0)
+                total_thought_entries = total_thought_entries + (data.thought_entry_count or 0)
+                if (data.underline_count or 0) > 0 then
+                    fetched[#fetched + 1] = {
+                        uid = ch.uid, title = ch.title, book_id = bid,
+                        underlines = data.underlines, review_map = data.review_map,
+                    }
+                end
+                if #(data.review_groups or {}) > 0 then
+                    local ok_save, saved = pcall(deps.save_thoughts, ch.book_id, ch.uid, data.review_groups)
+                    if ok_save and saved then
+                        thoughts_saved = thoughts_saved + 1
+                    else
+                        save_failures = save_failures + 1
+                        thought_save_failed[tostring(ch.uid)] = true
+                    end
+                end
+            else
+                hard_failures = hard_failures + 1
+                consecutive_hard = consecutive_hard + 1
+                if not good then
+                    last_error = tostring(data)
+                elseif type(data) == "table" then
+                    last_error = tostring((data.errors or {})[1] or last_error or "接口返回异常")
+                end
+                -- 断网熔断:连续多章整章失败(每章重试要吃满超时)不能逐章磨完全书。
+                -- 最后一章失败时不熔断,让已取到的数据走完正常出口。
+                if consecutive_hard >= 3 and i < #chapter_list then
+                    return nil, string.format("连续 %d 章拉取失败,已中止同步。\n最后错误:%s",
+                        consecutive_hard, short_err(last_error))
                 end
             end
-        else
-            hard_failures = hard_failures + 1
-            consecutive_hard = consecutive_hard + 1
-            if not good then
-                last_error = tostring(data)
-            elseif type(data) == "table" then
-                last_error = tostring((data.errors or {})[1] or last_error or "接口返回异常")
+            if not chapter_rate_limited and not skipped_completed_cache then
+                batch_start_index = batch_start_index or i
+                batch_end_index = i
+                chapters_processed = chapters_processed + 1
+                if good and type(data) == "table" and data.underline_request_ok ~= false
+                    and #(data.errors or {}) == 0 then
+                    chapters_fetch_succeeded = chapters_fetch_succeeded + 1
+                end
             end
-            -- 断网熔断:连续多章整章失败(每章重试要吃满超时)不能逐章磨完全书。
-            -- 最后一章失败时不熔断,让已取到的数据走完正常出口。
-            if consecutive_hard >= 3 and i < #chapter_list then
-                return nil, string.format("连续 %d 章拉取失败,已中止同步。\n最后错误:%s",
-                    consecutive_hard, short_err(last_error))
+            book_next = rate_limited and i or (i + 1)
+            if rate_limited then
+                chapters_pending = chapters_pending + (#chapter_list - book_next + 1)
+                break
             end
+            i = i + 1
         end
-        if not chapter_rate_limited and not skipped_completed_cache then
-            batch_start_index = batch_start_index or i
-            batch_end_index = i
-            chapters_processed = chapters_processed + 1
-            if good and type(data) == "table" and data.underline_request_ok ~= false
-                and #(data.errors or {}) == 0 then
-                chapters_fetch_succeeded = chapters_fetch_succeeded + 1
-            end
+        if chapters_pending == 0 and book_next ~= nil and book_next <= #chapter_list then
+            chapters_pending = chapters_pending + (#chapter_list - book_next + 1)
         end
-        next_index = rate_limited and i or (i + 1)
-        if rate_limited then
-            chapters_pending = #chapter_list - next_index + 1
-            break
-        end
-        i = i + 1
+        next_index = book_next
+        return true
     end
-    if chapters_pending == 0 and next_index <= #chapter_list then
-        chapters_pending = #chapter_list - next_index + 1
+
+    for _, bid in ipairs(book_ids) do
+        local ok, err = fetch_book(bid)
+        if not ok then return nil, err end
     end
     local function with_batch_fields(report)
         report.batch_start = batch_start_index
         report.batch_end = batch_end_index
         report.chapters_processed = chapters_processed
         report.chapters_fetch_succeeded = chapters_fetch_succeeded
-        report.batch_limit = chapter_budget or fetch_budget or #chapter_list
+        report.batch_limit = chapter_budget or fetch_budget or chapters_total_all
         return report
     end
     if hard_failures > 0 and #fetched == 0 then
@@ -206,12 +258,12 @@ function Sync.run(deps)
                 hard_failures, short_err(last_error))
         end
         if chapters_pending > 0 and not rate_limited then
-            return nil, string.format("本批 %d 章都没有划线;还剩 %d 章,再次同步继续拉取",
-                #chapter_list - chapters_pending, chapters_pending)
+            return nil,                 string.format("本批 %d 章都没有划线;还剩 %d 章,再次同步继续拉取",
+                chapters_total_all - chapters_pending, chapters_pending)
         end
         if not skip_resumed and not rate_limited then return nil, "这本书在微信读书里没有划线" end
         return with_batch_fields{
-            no_changes = true, chapters_total = #chapter_list,
+            no_changes = true, chapters_total = chapters_total_all,
             chapters_pending = chapters_pending, next_index = next_index,
             total_underlines = 0, total_thought_entries = 0,
             chapters_with_data = 0, chapters_matched = 0,
@@ -233,29 +285,36 @@ function Sync.run(deps)
         -- 指纹 = 源书大小 + 匹配算法版本:换书或改算法都让旧映射作废重建。
         local map_source = file_exists(backup) and backup or doc_path
         map_signature = tostring(U.file_size(map_source) or 0) .. "@" .. tostring(ChapterMap.ALGO_VERSION)
-        local raw = U.read_file(deps.map_cache_path, true)
-        if raw then
-            local ok_decode, decoded = pcall(Json.decode, raw)
-            if ok_decode and type(decoded) == "table"
-                and tostring(decoded.signature) == map_signature
-                and type(decoded.map) == "table" then
-                map_store = decoded.map
+        -- 多书:汇总每本书的独立缓存文件(命名空间化键);单书:沿用原缓存文件。
+        map_store = {}
+        for _, bid in ipairs(book_ids) do
+            local cp = cache_path_for(bid)
+            local raw = U.read_file(cp, true)
+            if raw then
+                local ok_decode, decoded = pcall(Json.decode, raw)
+                if ok_decode and type(decoded) == "table"
+                    and tostring(decoded.signature) == map_signature
+                    and type(decoded.map) == "table" then
+                    for k, v in pairs(decoded.map) do
+                        map_store[ck(bid, k)] = v
+                    end
+                end
             end
         end
-        map_store = map_store or {}
     end
 
     -- 缓存值格式:false = 确认无法匹配;{hrefs={...}, num=true|nil} =
     -- 目标文件列表(拆分章多目标),num 表示单目标强投票、允许数字兜底。
     local known, todo = {}, {}
     for _, ch in ipairs(fetched) do
-        local cached = map_store and map_store[tostring(ch.uid)]
+        local key = ck(ch.book_id, ch.uid)
+        local cached = map_store and map_store[key]
         if cached == nil then
             todo[#todo + 1] = ch
         elseif cached == false then
-            known[tostring(ch.uid)] = false
+            known[key] = false
         elseif type(cached) == "table" and type(cached.hrefs) == "table" and #cached.hrefs > 0 then
-            known[tostring(ch.uid)] = cached
+            known[key] = cached
         else
             todo[#todo + 1] = ch
         end
@@ -280,11 +339,71 @@ function Sync.run(deps)
     local map_count = 0
     local spine_total = #(map_meta.spine or {})
     local mapped_new, unmatched_new = {}, {}
+
+    -- B:spine 正文持久化缓存。仅当调用方显式开启 deps.spine_cache 且存在 map
+    -- 缓存、且本批确有新章节要匹配(todo>0)时启用;测试不开启,行为完全不变。
+    -- 第 2 批起直接读缓存文本,不再从 EPUB 解压每个 spine 文件、不再重复 normalize。
+    local spine_cache
+    if deps.spine_cache and deps.map_cache_path and #todo > 0 then
+        -- map_cache_path 可能是函数(多书),需先解析为字符串;spine 缓存按 EPUB 物理文件,
+        -- 多书共享同一本地书,取 book_ids[1] 即可。
+        local resolved_mcp = cache_path_for(book_ids[1])
+        local sc_dir = SpineCache.dir_for(resolved_mcp, map_signature)
+        if sc_dir then
+            spine_cache = SpineCache.open(sc_dir, map_signature)
+            logger.info("[撷思][SpineCache]", spine_cache and (spine_cache:warm() and "warm" or "cold") or "disabled",
+                "spine=", tostring(spine_total))
+        end
+    end
+    local real_read_text = deps.read_text
+    local real_read_spine = deps.read_spine
+    local function cached_read_text(m, href)
+        if spine_cache then
+            local cached = spine_cache:get(href)
+            if cached ~= nil then return cached end
+        end
+        local html = real_read_text and real_read_text(m, href)
+        if spine_cache then spine_cache:put(href, html) end
+        return html
+    end
+    local function cached_read_spine(m, callback)
+        if spine_cache then
+            if spine_cache:warm() and spine_cache:covers(m.spine) then
+                -- 暖模式:直接从缓存流式喂,完全不碰 EPUB。
+                for index, item in ipairs(m.spine or {}) do
+                    local html = spine_cache:get(item.href)
+                    callback(item, html, html == nil and "缓存缺失" or nil, index)
+                end
+                return true
+            end
+            if real_read_spine then
+                -- 冷模式:真实读取并捕获进缓存。
+                return real_read_spine(m, function(item, content, err, index)
+                    spine_cache:put(item.href, content)
+                    return callback(item, content, err, index)
+                end)
+            end
+            -- 无真实 read_spine:走 read_text 路径(仍经缓存)。
+            for index, item in ipairs(m.spine or {}) do
+                callback(item, cached_read_text(m, item.href), nil, index)
+            end
+            return true
+        end
+        -- 缓存未启用:完全等价于原行为,绝不会误调 read_text。
+        if real_read_spine then
+            return real_read_spine(m, callback)
+        end
+        for index, item in ipairs(m.spine or {}) do
+            callback(item, real_read_text and real_read_text(m, item.href), nil, index)
+        end
+        return true
+    end
+
     if #todo > 0 then
         local map_started_at = os.time()
         if deps.read_spine then
             mapped_new, unmatched_new = ChapterMap.build_stream(map_meta.spine, function(visit)
-                return deps.read_spine(map_meta, function(item, content, err, index)
+                return cached_read_spine(map_meta, function(item, content, err, index)
                     map_count = map_count + 1
                     step("map", map_count, spine_total, item and item.href)
                     visit(item, content, err, index)
@@ -294,72 +413,92 @@ function Sync.run(deps)
             mapped_new, unmatched_new = ChapterMap.build(map_meta.spine, function(href)
                 map_count = map_count + 1
                 step("map", map_count, spine_total, href)
-                return deps.read_text(map_meta, href)
+                return cached_read_text(map_meta, href)
             end, todo)
         end
+        if spine_cache then spine_cache:close() end
         logger.info("[撷思][ChapterMap] completed",
             "spine=", tostring(spine_total), "chapters=", tostring(#todo),
             "streamed=", tostring(deps.read_spine ~= nil),
+            "spine_cache=", spine_cache and (spine_cache:warm() and "warm" or "cold") or "off",
             "elapsed_s=", tostring(math.max(0, os.time() - map_started_at)))
     end
 
     -- 合并:按 fetched 原序拼装(拆分章一 uid 多行),新结果回写缓存。
     local new_rows_by_uid = {}
     for _, row in ipairs(mapped_new) do
-        local rows = new_rows_by_uid[row.chapter_uid] or {}
+        local key = ck(row.book_id, row.chapter_uid)
+        local rows = new_rows_by_uid[key] or {}
         rows[#rows + 1] = row
-        new_rows_by_uid[row.chapter_uid] = rows
+        new_rows_by_uid[key] = rows
     end
     local unmatched_uid = {}
     for _, row in ipairs(unmatched_new) do
-        if row.reason == "no_hit" then unmatched_uid[tostring(row.uid)] = true end
+        if row.reason == "no_hit" then unmatched_uid[ck(row.book_id, row.uid)] = true end
     end
     local mapped, unmatched = {}, {}
     local matched_uids = {}
     for _, ch in ipairs(fetched) do
-        local uid = tostring(ch.uid)
-        local cached = known[uid]
+        local key = ck(ch.book_id, ch.uid)
+        local cached = known[key]
         if type(cached) == "table" then
-            matched_uids[uid] = true
+            matched_uids[key] = true
             local quote_only = (not cached.num or #cached.hrefs > 1) or nil
             for _, href in ipairs(cached.hrefs) do
                 mapped[#mapped + 1] = {
-                    chapter_uid = uid, href = tostring(href),
+                    chapter_uid = tostring(ch.uid), href = tostring(href),
                     underlines = ch.underlines, review_map = ch.review_map or {},
-                    quote_only = quote_only,
+                    quote_only = quote_only, book_id = ch.book_id,
                 }
             end
         elseif cached == false then
-            unmatched[#unmatched + 1] = {uid = uid, title = ch.title, reason = "no_hit"}
-        elseif new_rows_by_uid[uid] then
-            matched_uids[uid] = true
+            unmatched[#unmatched + 1] = {uid = tostring(ch.uid), title = ch.title, reason = "no_hit", book_id = ch.book_id}
+        elseif new_rows_by_uid[key] then
+            matched_uids[key] = true
             local hrefs = {}
-            for _, row in ipairs(new_rows_by_uid[uid]) do
-                mapped[#mapped + 1] = row
+            for _, row in ipairs(new_rows_by_uid[key]) do
+                mapped[#mapped + 1] = {
+                    chapter_uid = tostring(ch.uid), href = row.href,
+                    underlines = ch.underlines, review_map = ch.review_map or {},
+                    quote_only = row.quote_only, book_id = ch.book_id,
+                }
                 hrefs[#hrefs + 1] = row.href
             end
             if map_store then
-                map_store[uid] = {hrefs = hrefs,
-                    num = (#hrefs == 1 and not new_rows_by_uid[uid][1].quote_only) or nil}
+                map_store[key] = {hrefs = hrefs,
+                    num = (#hrefs == 1 and not new_rows_by_uid[key][1].quote_only) or nil}
             end
-        elseif unmatched_uid[uid] then
-            unmatched[#unmatched + 1] = {uid = uid, title = ch.title, reason = "no_hit"}
-            if map_store then map_store[uid] = false end
+        elseif unmatched_uid[key] then
+            unmatched[#unmatched + 1] = {uid = tostring(ch.uid), title = ch.title, reason = "no_hit", book_id = ch.book_id}
+            if map_store then map_store[key] = false end
         else
             -- no_data(无划线)章节:不入缓存,下批有数据时再匹配。
-            unmatched[#unmatched + 1] = {uid = uid, title = ch.title, reason = "no_data"}
+            unmatched[#unmatched + 1] = {uid = tostring(ch.uid), title = ch.title, reason = "no_data", book_id = ch.book_id}
         end
     end
     if deps.map_cache_path and map_store then
-        local ok_encode, encoded = pcall(Json.encode, {signature = map_signature, map = map_store})
-        if ok_encode then U.atomic_write(deps.map_cache_path, encoded, true) end
+        -- 按书归组写回各自缓存文件(命名空间键拆回纯 uid);单书即原文件原格式。
+        local by_book = {}
+        for key, val in pairs(map_store) do
+            local bid, uid = key, key
+            if multi_book then bid, uid = key:match("^(.-)/(.*)$") end
+            bid = bid or book_ids[1]
+            uid = uid or key
+            by_book[bid] = by_book[bid] or {}
+            by_book[bid][uid] = val
+        end
+        for bid, m in pairs(by_book) do
+            local cp = cache_path_for(bid)
+            local ok_encode, encoded = pcall(Json.encode, {signature = map_signature, map = m})
+            if ok_encode then U.atomic_write(cp, encoded, true) end
+        end
     end
     -- 未匹配章节连带损失的划线数(报告要能说清"失败带走了多少")。
     local underlines_by_uid = {}
-    for _, ch in ipairs(fetched) do underlines_by_uid[tostring(ch.uid)] = #(ch.underlines or {}) end
+    for _, ch in ipairs(fetched) do underlines_by_uid[ck(ch.book_id, ch.uid)] = #(ch.underlines or {}) end
     local unmatched_underlines = 0
     for _, row in ipairs(unmatched) do
-        unmatched_underlines = unmatched_underlines + (underlines_by_uid[tostring(row.uid)] or 0)
+        unmatched_underlines = unmatched_underlines + (underlines_by_uid[ck(row.book_id, row.uid)] or 0)
     end
 
     if #mapped == 0 then
@@ -367,7 +506,7 @@ function Sync.run(deps)
             return nil, "没有任何章节能匹配到本地书,请确认绑定的和本地打开的是同一本书"
         end
         return with_batch_fields{
-            no_changes = true, chapters_total = #chapter_list,
+            no_changes = true, chapters_total = chapters_total_all,
             chapters_pending = chapters_pending, next_index = next_index,
             total_underlines = total_underlines,
             total_thought_entries = total_thought_entries,
@@ -381,15 +520,16 @@ function Sync.run(deps)
 
     if not step("inject", 0, 1) then return nil, "已取消" end
     -- 注入到中间文件(无 .epub 后缀,不会闪现在书架),成功后原子换位。
+    -- 多书时把所有绑定书的 mapped 章节合并进同一次注入,book_ids 一并列进 MARKER。
     local temp_dest = doc_path .. ".pickthought-new"
-    local stats, inject_err = deps.inject(src, deps.book_id, mapped, temp_dest,
-        {append = append, meta = meta})
+    local stats, inject_err = deps.inject(src, book_ids[1], mapped, temp_dest,
+        {append = append, meta = meta, book_ids = book_ids})
     if not stats then return nil, inject_err end
 
     -- 重叠划线被合并的,把想法并进存活锚点的组:点一个虚线看到这一段全部想法。
     if deps.merge_thoughts then
         for _, merge in ipairs(stats.merges or {}) do
-            pcall(deps.merge_thoughts, deps.book_id, merge.uid, merge.from, merge.into)
+            pcall(deps.merge_thoughts, merge.book_id or book_ids[1], merge.uid, merge.from, merge.into)
         end
     end
 
@@ -434,7 +574,7 @@ function Sync.run(deps)
         inject_unmatched = stats.unmatched,
         thoughts_saved = thoughts_saved,
         save_failures = save_failures,
-        chapters_total = #chapter_list,
+        chapters_total = chapters_total_all,
         chapters_with_data = #fetched,
         chapters_matched = (function()
             local n = 0

--- a/pickthought.koplugin/pickthought/sync_task.lua
+++ b/pickthought.koplugin/pickthought/sync_task.lua
@@ -491,6 +491,8 @@ function SyncTask:start(task, on_progress, on_done)
     local task_token = stamp .. "-" .. tostring(math.random(100000,999999))
     local doc_path = tostring(task.doc_path or "")
     local book_id = tostring(task.book_id or "")
+    -- 多书绑定:task.book_ids 为列表;未提供时回退到单个 book_id(旧调用/旧测试不变)。
+    local book_ids = (type(task.book_ids) == "table" and #task.book_ids > 0) and task.book_ids or {book_id}
     local doc_title = tostring(task.title or "")
     -- mode: "sync"=联网增量同步(复用缓存并按游标续传);"reinject"=纯离线,
     -- 只用上次拉取的数据重跑映射+注入,零网络。
@@ -550,18 +552,25 @@ function SyncTask:start(task, on_progress, on_done)
             -- 断点/复用缓存:每章拉取结果落盘。
             -- 成功的同步以 .completed 标记收尾并保留数据(供离线重注);
             -- 全新同步看到标记即清空重拉(同步=拿新的);无标记=中断残留,续传。
-            local cache_dir = store:book_dir(book_id) .. "/sync-cache"
-            UChild.mkdir(cache_dir)
-            local completed_marker = cache_dir .. "/.completed"
-            local state_path = cache_dir .. "/state.json"
+            -- 多书绑定:每本书有独立的 sync-cache 目录,缓存按 bid 命名空间隔离,
+            -- 避免合集里各子书的章节/映射缓存混在同一目录互相污染。
+            local function cache_for(bid)
+                local dir = store:book_dir(bid) .. "/sync-cache"
+                UChild.mkdir(dir)
+                return dir
+            end
+            local function cache_path_for(bid, uid)
+                return cache_for(bid) .. "/" .. UChild.id_name(uid) .. ".json"
+            end
+            local completed_marker = cache_for(book_id) .. "/.completed"
+            local state_path = cache_for(book_id) .. "/state.json"
             -- 不再清 .completed 缓存:已缓存的章节 resumed 跳过(免费),失败的(缓存
             -- 损坏/不存在)重拉。用户想全新重拉走「重置本书」。之前清缓存导致用户
             -- 点「同步」补齐失败章节时缓存全没(issue #2 评论)。
-            local function cache_path(uid) return cache_dir .. "/" .. UChild.id_name(uid) .. ".json" end
-            local chapters_cache_path = cache_dir .. "/chapters.json"
             -- 章节列表也入缓存,离线重注才能完全不碰网络。
             local api_for_sync = {
                 chapters = function(_, bid)
+                    local chapters_cache_path = cache_for(bid) .. "/chapters.json"
                     if mode == "reinject" then
                         local raw = UChild.read_file(chapters_cache_path, true)
                         if not raw then error("没有上次的同步数据,请先完整同步一次") end
@@ -611,7 +620,7 @@ function SyncTask:start(task, on_progress, on_done)
             end
             local cached_annotations = {
                 fetch_chapter = function(_, bid, uid)
-                    local raw = UChild.read_file(cache_path(uid), true)
+                    local raw = UChild.read_file(cache_path_for(bid, uid), true)
                     if raw then
                         local good, data = pcall(JsonChild.decode, raw)
                         if good and cache_valid(data) then
@@ -649,7 +658,7 @@ function SyncTask:start(task, on_progress, on_done)
                             errors = {}, underline_request_ok = true,
                         })
                         local enc_ok, encoded = pcall(JsonChild.encode, slim)
-                        if enc_ok then UChild.atomic_write(cache_path(uid), encoded, true) end
+                        if enc_ok then UChild.atomic_write(cache_path_for(bid, uid), encoded, true) end
                     end
                     -- 礼貌间隔:章与章之间随机停 200~400ms,请求速率贴近真人翻章。
                     FFIUtil.usleep((200 + math.random(0, 200)) * 1000)
@@ -670,8 +679,10 @@ function SyncTask:start(task, on_progress, on_done)
                     end
                 end
             end
-            for _, file in ipairs(UChild.list(cache_dir)) do
-                if file:match("%.tmp%-%d+%-%d+$") then os.remove(file) end
+            for _, bid in ipairs(book_ids) do
+                for _, file in ipairs(UChild.list(cache_for(bid))) do
+                    if file:match("%.tmp%-%d+%-%d+$") then os.remove(file) end
+                end
             end
 
             -- 注入前释放拉取阶段的网络缓存/JSON 对象,降内存水位(低内存设备防 OOM)
@@ -680,6 +691,7 @@ function SyncTask:start(task, on_progress, on_done)
             local report, sync_err = Sync.run{
                 doc_path = doc_path,
                 book_id = book_id,
+                book_ids = book_ids,
                 api = api_for_sync,
                 annotations = cached_annotations,
                 load_meta = function(p) return EpubReader.load(p) end,
@@ -712,7 +724,10 @@ function SyncTask:start(task, on_progress, on_done)
                 chapter_start = mode ~= "reinject" and chapter_start or 1,
                 skip_resumed = incremental and completed,
                 append = incremental and (completed or chapter_start > 1),
-                map_cache_path = cache_dir .. "/map.json",
+                -- 多书:每本书独立 map 缓存文件(按 bid 命名空间);单书退化为原文件。
+                map_cache_path = function(bid) return store:book_dir(bid) .. "/sync-cache/map.json" end,
+                -- B:开启 spine 正文持久化缓存,分批同步第 2 批起不再解压原 EPUB。
+                spine_cache = true,
                 progress = function(phase, i, n, text)
                     if cancelled() then return false end
                     local percent
@@ -734,17 +749,22 @@ function SyncTask:start(task, on_progress, on_done)
             -- 的真实批次状态抹掉(真机翻车:重注后续拉菜单消失)。
             if mode ~= "reinject" then
                 local pending = tonumber(report.chapters_pending) or 0
-                local state_ok, state_json = pcall(JsonChild.encode, {
+                local state_data = {
                     total = report.chapters_total, pending = pending,
                     next_index = tonumber(report.next_index) or (report.chapters_total + 1),
                     retry_after = report.rate_limit_wait and (os.time() + report.rate_limit_wait) or nil,
                     updated_at = os.time(),
-                })
-                if state_ok then UChild.atomic_write(cache_dir .. "/state.json", state_json, true) end
-                -- 全部章节拉完才算「完成」:打标记保留缓存供离线重注,
-                -- 下次全新同步看到标记会清空重拉;分批未完/取消/失败不打标记=续传。
-                if pending == 0 then
-                    UChild.atomic_write(completed_marker, tostring(os.time()), true)
+                }
+                -- 每本书独立写状态/完成标记(各自保留离线重注缓存);
+                -- 多书时 state 数值是聚合值,续拉菜单以主绑定为准,仅作提示。
+                for _, bid in ipairs(book_ids) do
+                    local state_ok, state_json = pcall(JsonChild.encode, state_data)
+                    if state_ok then UChild.atomic_write(cache_for(bid) .. "/state.json", state_json, true) end
+                    -- 全部章节拉完才算「完成」:打标记保留缓存供离线重注,
+                    -- 下次全新同步看到标记会清空重拉;分批未完/取消/失败不打标记=续传。
+                    if pending == 0 then
+                        UChild.atomic_write(cache_for(bid) .. "/.completed", tostring(os.time()), true)
+                    end
                 end
             end
             return {report = report, auth = store:auth()}

--- a/pickthought.koplugin/pickthought/thoughts.lua
+++ b/pickthought.koplugin/pickthought/thoughts.lua
@@ -13,8 +13,28 @@ local lfs = require("libs/libkoreader-lfs")
 local Thoughts = {}
 
 -- per-book SQLite 句柄缓存:点击锚点时避免反复 open/close。
+-- KPW3 红线:句柄不得无上限累积——纯阅读期跨多本注入书点锚点会 slowly 涨内存
+-- (每个句柄连带 SQLite + WAL 文件)。加 LRU 上限,超出关最久未用,释放文件句柄。
 local db_cache = {}
+local db_cache_order = {}   -- LRU 顺序:表头最久未用,表尾最近使用
+local DB_CACHE_MAX = 4
 local migrated = {}  -- book_dir → 已检查旧 JSON 迁移(进程内不重复扫)
+
+local function db_cache_touch(book_dir)
+    for i, v in ipairs(db_cache_order) do
+        if v == book_dir then table.remove(db_cache_order, i); break end
+    end
+    db_cache_order[#db_cache_order + 1] = book_dir
+end
+
+local function db_cache_evict()
+    while #db_cache_order > DB_CACHE_MAX do
+        local old = table.remove(db_cache_order, 1)
+        local db = db_cache[old]
+        if db then pcall(ThoughtDB.close, db) end
+        db_cache[old] = nil
+    end
+end
 
 local function hex_encode(value)
     return (tostring(value or ""):gsub(".", function(ch)
@@ -94,10 +114,15 @@ end
 local function open_db(store, book_id)
     local book_dir = store:book_dir(book_id)
     local db = db_cache[book_dir]
-    if db then return db end
+    if db then
+        db_cache_touch(book_dir)
+        return db
+    end
     db = ThoughtDB.open(book_dir)
     if not db then return nil end
     db_cache[book_dir] = db
+    db_cache_touch(book_dir)
+    db_cache_evict()
     if not migrated[book_dir] then
         migrated[book_dir] = true
         local ok_mig = pcall(migrate_legacy, book_id, book_dir, db)
@@ -252,9 +277,24 @@ function Thoughts.popup_text(group)
 end
 
 function Thoughts.clear_memory_cache()
-    for _, db in pairs(db_cache) do ThoughtDB.close(db) end
+    for _, db in pairs(db_cache) do pcall(ThoughtDB.close, db) end
     db_cache = {}
+    db_cache_order = {}
     -- migrated 不清:进程内已迁移的 book 不重复扫(目录已空,下次也跳过)。
+end
+
+-- 关闭单本书句柄(阅读端关闭文档时调用),释放 SQLite + WAL 文件。
+-- 之后若再点该书的锚点,open_db 会重新打开,无害。
+function Thoughts.close_book(store, book_id)
+    local book_dir = store:book_dir(book_id)
+    local db = db_cache[book_dir]
+    if db then
+        pcall(ThoughtDB.close, db)
+        db_cache[book_dir] = nil
+        for i, v in ipairs(db_cache_order) do
+            if v == book_dir then table.remove(db_cache_order, i); break end
+        end
+    end
 end
 
 return Thoughts

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -24,8 +24,9 @@ _G.STUBS = require("tests.stubs")
 local files = {
     "tests.test_smoke", "tests.test_epub_reader", "tests.test_epub_inject",
     "tests.test_binding", "tests.test_chapter_map", "tests.test_sync",
-    "tests.test_sync_report", "tests.test_batch_sync",
+    "tests.test_sync_report",     "tests.test_batch_sync",
     "tests.test_web_fetch", "tests.test_power_inhibit", "tests.test_sync_task",
+    "tests.test_spine_cache",
     "tests.test_thought_db", "tests.test_thoughts",
 }
 for _, name in ipairs(files) do

--- a/tests/test_binding.lua
+++ b/tests/test_binding.lua
@@ -1,5 +1,11 @@
 local Binding = require("pickthought.binding")
 
+local function count(t)
+    local n = 0
+    for _ in pairs(t) do n = n + 1 end
+    return n
+end
+
 T.case("normalize_search 容错三种形状", function()
     local nested = {books = {
         {bookInfo = {bookId = "b1", title = "春江花月夜", author = "张若虚"}},
@@ -73,6 +79,22 @@ T.case("normalize_chapters 容错与排序", function()
     T.eq(#Binding.normalize_chapters(nil), 0, "nil 安全")
 end)
 
+T.case("normalize_chapters 认真实 web 端点形状(顶层 chapters)", function()
+    -- 真机实测 /web/book/chapterInfos 返回 {bookId?, synckey?, chapters:[...]}
+    local real = {bookId = "22584111", synckey = 1119519248,
+        chapters = {
+            {chapterUid = 1, title = "封面", chapterIdx = 1},
+            {chapterUid = 3, title = "临讲", chapterIdx = 2},
+        }}
+    local rows = Binding.normalize_chapters(real, "22584111")
+    T.eq(#rows, 2, "顶层 chapters 直接识别")
+    T.eq(rows[1].uid, "1", "uid 提取")
+    T.eq(rows[2].uid, "3", "保留原 chapterUid(非连续)")
+    -- 无 bookId 字段的返回(仅 synckey)也应识别,这是 40638616 失败的形态
+    local no_book = {synckey = 1, chapters = {{chapterUid = 1, title = "x", chapterIdx = 1}}}
+    T.eq(#Binding.normalize_chapters(no_book), 1, "无 bookId 仍识别 chapters")
+end)
+
 T.case("绑定存取清", function()
     local kv = {}
     local store = {
@@ -99,4 +121,64 @@ T.case("normalize_search 标注版本类型(format)", function()
     T.eq(rows[1].title, "剑来 [网络]", "txt 标网络")
     T.eq(rows[2].title, "剑来精校 [出版]", "epub 标出版")
     T.eq(rows[3].title, "未知版", "无 format 不标注")
+end)
+
+T.case("绑定支持一本本地书绑多本微信读书书(1:N)", function()
+    local kv = {}
+    local store = {
+        get = function(_, k, d) return kv[k] ~= nil and kv[k] or d end,
+        set = function(_, k, v) kv[k] = v end,
+    }
+    local path = "/books/合集.epub"
+    Binding.save(store, path, {book_id = "b1", title = "甲", author = "作者A"})
+    Binding.save(store, path, {book_id = "b2", title = "乙", author = "作者B"})
+    local records = Binding.records(store, path)
+    T.eq(count(records), 2, "两本并存")
+    T.ok(records["b1"] and records["b2"], "按 book_id 建 map")
+    -- 同 book_id 覆盖,不新增
+    Binding.save(store, path, {book_id = "b1", title = "甲(修订)"})
+    T.eq(count(Binding.records(store, path)), 2, "同 id 覆盖不新增")
+    T.eq(Binding.get_record(store, path, "b1").title, "甲(修订)", "覆盖生效")
+    -- 移除一本,另一本仍在
+    Binding.remove(store, path, "b1")
+    T.eq(count(Binding.records(store, path)), 1, "移除后剩一本")
+    T.ok(Binding.get_record(store, path, "b2"), "另一本保留")
+    -- 移除最后一本质空(map 退化空表,键从 bindings 中清除)
+    Binding.remove(store, path, "b2")
+    T.eq(count(Binding.records(store, path)), 0, "全移除后键被清")
+end)
+
+T.case("绑定旧单键格式自动迁移为 1:N map", function()
+    local kv = {}
+    local store = {
+        get = function(_, k, d) return kv[k] ~= nil and kv[k] or d end,
+        set = function(_, k, v) kv[k] = v end,
+    }
+    local path = "/books/旧.epub"
+    -- 旧版:all[doc_path] 直接是单条记录
+    kv["bindings"] = {[path] = {book_id = "old1", title = "旧书", bound_at = 100}}
+    local rec = Binding.get(store, path)
+    T.eq(rec.book_id, "old1", "旧格式可读")
+    -- 读取即迁移并落盘
+    local migrated = kv["bindings"][path]
+    T.ok(type(migrated) == "table" and migrated["old1"], "已迁移为 map")
+    -- 迁移后仍能正常加第二本
+    Binding.save(store, path, {book_id = "old2", title = "新书"})
+    T.eq(count(Binding.records(store, path)), 2, "迁移后可继续 1:N")
+end)
+
+T.case("Binding.get 返回最近绑定的主书,list 按时间升序", function()
+    local kv = {}
+    local store = {
+        get = function(_, k, d) return kv[k] ~= nil and kv[k] or d end,
+        set = function(_, k, v) kv[k] = v end,
+    }
+    local path = "/books/p.epub"
+    Binding.save(store, path, {book_id = "first", bound_at = 10})
+    Binding.save(store, path, {book_id = "second", bound_at = 20})
+    T.eq(Binding.get(store, path).book_id, "second", "最近绑定为主")
+    local list = Binding.list(store, path)
+    T.eq(#list, 2, "list 两本")
+    T.eq(list[1].book_id, "first", "list 首为最早")
+    T.eq(list[2].book_id, "second", "list 末尾最近")
 end)

--- a/tests/test_epub_inject.lua
+++ b/tests/test_epub_inject.lua
@@ -68,7 +68,7 @@ T.case("端到端注入", function()
     for _, e in ipairs(entries) do by_path[e.path] = e end
     local ch1 = by_path["OEBPS/Text/ch1.xhtml"]
     T.ok(ch1.compression == "deflate", "正文用 deflate")
-    T.ok(ch1.content:find('class="pickthought-mark', 1, true), "锚点 span 注入")
+    T.ok(ch1.content:find('pickthought-mark', 1, true), "锚点 span 注入")
     T.ok(ch1.content:find('href="#pickthought-', 1, true), "想法链接注入(专属前缀)")
     T.ok(ch1.content:find('id="pickthought-annotation-style"', 1, true), "内联样式注入 head")
     T.ok(ch1.content:find("</title>", 1, true) and ch1.content:find("春江潮水", 1, true), "原结构保留")

--- a/tests/test_spine_cache.lua
+++ b/tests/test_spine_cache.lua
@@ -1,0 +1,59 @@
+-- SpineCache 单元测试:冷模式捕获 → 暖模式命中,内容字节一致;指纹变更作废。
+-- 用内存 FS 替身临时替换 U 的磁盘函数(测试环境的 lfs 是 no-op,无法真正建目录),
+-- 验证完立即还原,不影响其他用例。
+local SpineCache = require("pickthought.spine_cache")
+local U = require("pickthought.util")
+
+local CH1 = "<html><body><p>春江潮水连海平。</p></body></html>"
+local CH2 = "<html><body><p>海上明月共潮生。</p></body></html>"
+
+T.case("SpineCache: 冷捕→暖服 内容一致且指纹作废", function()
+    local saved = {}
+    for _, k in ipairs({"mkdir", "read_file", "file_exists", "atomic_write", "remove_tree", "list"}) do
+        saved[k] = U[k]
+    end
+    local fs = {}
+    U.mkdir = function(p) fs[tostring(p)] = fs[tostring(p)] or true; return true end
+    U.file_exists = function(p) return fs[tostring(p)] ~= nil end
+    U.read_file = function(p) local c = fs[tostring(p)]; return c == true and nil or c end
+    U.atomic_write = function(p, d) fs[tostring(p)] = d; return true end
+    U.remove_tree = function(p)
+        local pk = tostring(p)
+        for k in pairs(fs) do
+            if k == pk or k:sub(1, #pk + 1) == pk .. "/" then fs[k] = nil end
+        end
+        return true
+    end
+    U.list = function(p)
+        local o = {}; local pre = tostring(p) .. "/"
+        for k in pairs(fs) do if k:sub(1, #pre) == pre then o[#o + 1] = k end end
+        return o
+    end
+
+    local dir = "tests/.tmp_spine/spine-12345_7"
+    local sig = "12345@7"
+    local spine = {{href = "OEBPS/c1.xhtml"}, {href = "OEBPS/c2.xhtml"}}
+
+    -- 冷模式:捕获两个 spine 文件
+    local cold = SpineCache.open(dir, sig)
+    T.ok(cold and not cold:warm(), "冷模式开启")
+    cold:put("OEBPS/c1.xhtml", CH1)
+    cold:put("OEBPS/c2.xhtml", CH2)
+    cold:close()
+
+    -- 暖模式:命中,内容字节一致,covers 全中
+    local warm = SpineCache.open(dir, sig)
+    T.ok(warm and warm:warm(), "暖模式命中已有缓存")
+    T.ok(warm:covers(spine), "covers 覆盖全部 href")
+    T.eq(warm:get("OEBPS/c1.xhtml"), CH1, "c1 内容一致")
+    T.eq(warm:get("OEBPS/c2.xhtml"), CH2, "c2 内容一致")
+
+    -- 缺 href 的 spine 不应被 covers(暖路径会回退真实读取)
+    T.ok(not warm:covers({{href = "OEBPS/missing.xhtml"}}), "缺 href 不 covers")
+
+    -- 指纹变更(换书/升算法)→ 旧缓存整体作废,回到冷模式
+    local other = SpineCache.open(dir, "99999@8")
+    T.ok(other and not other:warm(), "指纹不符→冷模式重捕")
+
+    for k, v in pairs(saved) do U[k] = v end
+end)

--- a/tests/test_sync.lua
+++ b/tests/test_sync.lua
@@ -314,7 +314,7 @@ T.case("分批预算:拉满即收工,缓存命中免费", function()
     for i = 1, 10 do rows[i] = {chapterUid = i, title = "第" .. i .. "章", chapterIdx = i} end
     local network_calls = 0
     local deps, calls = make_deps({
-        api = {chapters = function() return {data = rows} end},
+        api = {chapters = function() return {chapters = rows} end},
         annotations = {
             fetch_chapter = function(_, _, uid)
                 local n = tonumber(uid)
@@ -361,7 +361,7 @@ T.case("章节批次预算限制缓存回放,不再一次性注入全书", funct
     for i = 1, 10 do rows[i] = {chapterUid = i, title = "第" .. i .. "章", chapterIdx = i} end
     local fetch_calls = 0
     local deps, calls = make_deps({
-        api = {chapters = function() return {data = rows} end},
+        api = {chapters = function() return {chapters = rows} end},
         annotations = {
             fetch_chapter = function()
                 fetch_calls = fetch_calls + 1
@@ -388,7 +388,7 @@ T.case("已完成缓存续同步跳过旧章,只注入新章", function()
     local rows = {}
     for i = 1, 5 do rows[i] = {chapterUid = i, title = "第" .. i .. "章", chapterIdx = i} end
     local deps, calls = make_deps({
-        api = {chapters = function() return {data = rows} end},
+        api = {chapters = function() return {chapters = rows} end},
         annotations = {
             fetch_chapter = function(_, _, uid)
                 if tonumber(uid) < 5 then
@@ -441,7 +441,7 @@ T.case("连续硬失败触发断网熔断", function()
     for i = 1, 10 do rows[i] = {chapterUid = i, title = "第" .. i .. "章", chapterIdx = i} end
     local fetch_count = 0
     local deps, calls = make_deps({
-        api = {chapters = function() return {data = rows} end},
+        api = {chapters = function() return {chapters = rows} end},
         annotations = {
             fetch_chapter = function() fetch_count = fetch_count + 1; error("network request failed") end,
         },
@@ -458,7 +458,7 @@ T.case("断点缓存命中不复位熔断计数", function()
     for i = 1, 7 do rows[i] = {chapterUid = i, title = "第" .. i .. "章", chapterIdx = i} end
     local fetch_calls = 0
     local deps = make_deps({
-        api = {chapters = function() return {data = rows} end},
+        api = {chapters = function() return {chapters = rows} end},
         annotations = {
             fetch_chapter = function(_, _, uid)
                 fetch_calls = fetch_calls + 1
@@ -483,7 +483,7 @@ T.case("末尾连续失败且成功章节无划线时报拉取失败而非无划
     local rows = {}
     for i = 1, 4 do rows[i] = {chapterUid = i, title = "第" .. i .. "章", chapterIdx = i} end
     local deps = make_deps({
-        api = {chapters = function() return {data = rows} end},
+        api = {chapters = function() return {chapters = rows} end},
         annotations = {
             fetch_chapter = function(_, _, uid)
                 if tostring(uid) == "1" then
@@ -527,4 +527,66 @@ T.case("单章拉取失败不中断,计入 fetch_errors", function()
     T.ok(report, "应成功: " .. tostring(err))
     T.eq(report.fetch_errors, 1, "失败章节计数")
     T.eq(report.injected, 1, "成功章节照常注入")
+end)
+
+T.case("多书绑定:一次同步聚合多本微信读书书并合并注入", function()
+    -- 模拟「一本本地合集 EPUB 绑了 b001、b002 两本微信读书书」。
+    -- 两本各自有第一章(划线一致,都能映射到本地 c1);验证:两本都被拉取、
+    -- 注入的 mapped 合并了两本的章节(各自带 book_id)、inject 收到完整 book_ids。
+    local api_calls = {}
+    local fetch_calls = {}
+    local deps, calls = make_deps({
+        book_ids = {"b001", "b002"},
+        api = {
+            chapters = function(_, bid)
+                api_calls[#api_calls + 1] = tostring(bid)
+                local suffix = tostring(bid)
+                return {chapters = {
+                    {chapterUid = 1, title = "第一章(" .. suffix .. ")", chapterIdx = 1},
+                    {chapterUid = 2, title = "第二章(" .. suffix .. ")", chapterIdx = 2},
+                }}
+            end,
+        },
+        annotations = {
+            fetch_chapter = function(_, bid, uid)
+                fetch_calls[#fetch_calls + 1] = {book_id = tostring(bid), uid = tostring(uid)}
+                if tostring(uid) == "1" then
+                    return {
+                        underlines = {{range = "0-7", markText = "春江潮水连海平"}},
+                        review_map = {["0-7"] = {{content = "好句", author = "甲"}}},
+                        review_groups = {{range = "0-7", texts = {{content = "好句", author = "甲"}}}},
+                        underline_count = 1, thought_count = 1, thought_entry_count = 1, errors = {},
+                    }
+                end
+                return {underlines = {}, review_map = {}, review_groups = {},
+                    underline_count = 0, thought_count = 0, thought_entry_count = 0, errors = {}}
+            end,
+        },
+    })
+    local report, err = Sync.run(deps)
+    T.ok(report, "多书聚合应成功: " .. tostring(err))
+
+    -- 两本书的章节列表都被请求过(逐本拉取聚合)。
+    T.eq(#api_calls, 2, "按 book_ids 逐本拉取章节列表")
+    T.ok(api_calls[1] == "b001" and api_calls[2] == "b002", "先拉 b001 再拉 b002")
+
+    -- 章节总数为两本之和;有划线的章节为两本各自的第一章。
+    T.eq(report.chapters_total, 4, "章节总数=两本之和")
+    T.eq(report.chapters_with_data, 2, "两本各有 1 章有划线")
+
+    -- 注入的 mapped 合并了两本书的章节,且每行都带正确的 book_id。
+    local books_in_mapped = {}
+    for _, row in ipairs(calls.injected.mapped) do
+        books_in_mapped[row.book_id] = true
+    end
+    T.eq(#calls.injected.mapped, 2, "合并注入两本各有 1 章")
+    T.ok(books_in_mapped["b001"] and books_in_mapped["b002"], "两本都在注入结果里")
+
+    -- inject 调用收到完整 book_ids(解决「换绑漏书」的根因:一次性合并重建)。
+    T.eq(type(calls.injected.options.book_ids), "table", "inject 选项携带 book_ids")
+    T.eq(calls.injected.options.book_ids[1], "b001", "book_ids 含 b001")
+    T.eq(calls.injected.options.book_ids[2], "b002", "book_ids 含 b002")
+
+    -- 多书强制干净重建(不走增量 append),从原书/备份读取而非当前注入版。
+    T.eq(calls.injected.options.append, false, "多书强制全量重建,不增量追加")
 end)


### PR DESCRIPTION
# PR 说明（面向原作者 / Maintainer）

> 标题建议：**fix + perf: 修复崩溃与"无划线"问题，并优化低内存墨水屏的注入与同步**

> 📌 **想看逐文件改动、回退说明等技术细节？** 本文只讲「改了什么、为什么」，便于快速审阅；完整的改动清单同样记录在 commit message 中，直接看本 PR 的逐文件 diff 即可定位每一处改动与对应源码位置，便于你深入审查。

## 这是个什么 PR

撷思能把你在微信读书里的划线、想法注入到本地 EPUB 里一起看。这个 PR 主要做两件事：
1. **修掉两个会让插件用不了的原版 BUG**（崩溃、绑定后读不到划线）；
2. **做了几处让低内存墨水屏（如 Kindle Paperwhite 3）更好用的优化**（注入更稳、同步更快、能绑多本）。

**所有改动都向后兼容**：没有改动任何已有的文件结构或标识符，注入出来的 EPUB 数据内容与以前一致（仅高亮渲染样式由虚线改为下划线，属下方「五、追加修复」边框修复的一部分，不影响划线/想法数据与点击）。

---

## 一、修掉的 BUG（原版就有的问题）

### BUG 1：打开一本已经注入划线的书，KOReader 直接崩了

- **用户看到的样子**：在 KPW3 这类内存小的设备上，打开一本被注入过划线的书会闪退，根本看不了。
- **为什么会这样**：插件在注入每一条划线时，额外加了一个"全世界只此一份、谁也不会用到"的样式标记。书里成百上千条划线，就被当成成百上千份几乎一样的样式，把渲染引擎的样式内存撑爆了。
- **怎么修的**：删掉那个没用的标记，只留真正需要的样式。划线照样显示、照样能点开、计数也照旧——肉眼看不出任何区别。
- **性质**：这是原版从一开始就有的设计缺陷，不是这次其他优化带进来的。

### BUG 2：明明绑了书，却一直提示"这本书没有划线"

- **用户看到的样子**：本地书已经成功绑定微信读书，一同步却弹"这本书在微信读书里没有划线"，划线注不进去。
- **为什么会这样**：插件读微信读书章节列表的代码只认老接口的旧格式，没认出新接口返回的真实数据，于是把章节列表读成了空，自然一条划线也匹配不到。
- **怎么修的**：让它正确读取真实返回的章节字段（老格式仍然兼容兜底）。之后绑定就能正常匹配并注入划线了。

---

## 二、新增 / 优化的功能

### 1. 注入大书时更不容易内存崩溃

- **做了什么**：注入过程中遇到大块内容（如图片、字体内嵌）时，改成在磁盘上中转拷贝，而不是全部塞进内存。
- **好处**：消除了注入大书时的内存尖峰，低内存设备注入更稳；万一中转失败会自动退回原做法，不影响功能。

### 2. 分批同步明显变快

- **做了什么**：新增"正文缓存"——第二次及以后的同步直接从缓存读取，不再反复解压原 EPUB、也不再重复解析。
- **好处**：书越厚、同步批次越多，省的时间越明显。该缓存默认关闭，只有真正走同步时才启用，不影响其他行为。

### 3. 长时间看多本书时更省资源

- **做了什么**：给"每本书的本地数据库（SQLite）连接"加了上限（最多同时 4 个），并在合上某本书时释放它。
- **好处**：避免连着看很多本、反复点划线时，数据库连接无限堆积占内存。只管开关，没动数据库结构。

### 4. 一本书可以同时绑定多本微信读书书（合集 / 套装神器）

- **做了什么**：原来一本本地书只能绑一本微信读书书（1:1）。现在支持 1:N——一套合集 EPUB 能同时绑多本微信读书书。每次同步会把所有绑定书的划线汇总，从干净备份整体重建、**一次性合并注入**。
- **好处**：彻底解决旧模型"换绑第二本会把第一本已注入的想法覆盖掉"的数据丢失问题；原来要反复解绑、重绑，现在一次绑多本、一次拉全。
- **配套界面**：已绑定时，书的菜单会直接进「管理绑定」页，每本书都能单独**换绑 / 解绑**，不用再"全解绑 → 挨个重绑"。
- **附注（非原版缺陷）**：做这个功能时我顺手修了两个自己引入的小问题：① 每书缓存路径改成函数后，调用处没跟着改导致同步中途崩溃——已修；② 管理绑定弹窗操作完列表不刷新——已修。

---

## 三、验证情况

- 单元测试和集成测试全过（含多书绑定、崩溃修复的新增用例）。
- 已在 KPW3 真机验证：注入不再崩溃、多书绑定与列表刷新正常。
- 兼容性：旧版的单绑定数据、原 `.orig` 备份、第三方 `pickthought.json` 解析都不受影响；版本号未变（保持 0.2.3），由你来定何时发版。

---

## 四、验收报告（插件加载与运行核验）

用 `koplugin-load-check` 三步法对所有改动文件做了加载期与运行期验收，结论：**插件可正常加载、运行，达到提 PR 条件。**

- **类顺序检查**：10 个改动文件全部通过（无方法定义在类声明之前）。
- **宽松代理加载**：review 源与设备部署版 `main.lua` 均 `LOAD_OK`，两版一致。
- **`local _` 遮蔽**：报告 2 处经人工确认安全——`main.lua` 顶层 `local _ = Text.tr`（gettext 别名）、`epub_inject.lua` 内 `local _, x = html:find(...)`（函数体无翻译调用，丢弃首返回值是正常的）。
- **单元测试**：`129 passed / 0 failed`。
- **真机落地核验**：设备上 4 处核心修复（E / F1 / F2 / F3+取消）均已就位；改动落地后零崩溃、零回归。`crash.log` 仅剩早前崩溃的历史记录，以及微信读书登录态过期的常规告警（与改动无关）。

> 📌 **技术细节去哪看**：本文只概述改动与原因。若你想逐文件核对改动、了解每段的可回退性，直接看本 PR 的 commit message 与逐文件 diff 即可——所有改动点都对应到具体源码位置，无需额外文件。

---

## 五、本 PR 追加的修复（开书崩溃，独立于 BUG 1）

> 这是 PR 初次提交后又发现并修掉的一个**独立**问题，与 BUG 1（唯一 class 撑爆样式内存）**不是同一回事**，请勿混为一谈。

### 现象
本地书绑定多本微信读书书并注入后，打开这本合集 EPUB（数千条划线）会在**开书渲染时**直接 `Killed` 崩溃。

### 根因
每条带想法的划线会生成一个带 `border-bottom: 2px dashed`（盒子边框）的 `pickthought-mark` span。CRE 渲染引擎对**每个「盒子边框」元素**在样式数据缓存里的开销，远高于「纯链接（`text-decoration:none`）」元素。多书合集数千个虚线边框 span，在默认 10MB（`cre_storage_size_factor=40`）缓存下直接溢出 → 崩溃。
（对照实证：另一本《神秘复苏》注入了 **3.4 万个无边框**链接元素却能正常打开——证明是「边框元素贵」，不是「元素多」；最初的"元素过多"判断已被这本反例推翻。）

### 修复（commit `a1bdbd5`）
1. `annotation_style.lua`：去掉盒子边框，改为 `text-decoration: underline`（单价与纯链接一致）；`is_current` 的"样式是否最新"判定串同步改为 `color:#ff6b35`，否则改完 CSS 后每次开书都误判"样式过期"而重写。
2. `annotations.lua`：把「`<a>` 套 `<span>`」两层折叠为单个 `<a class="pickthought-link pickthought-mark">`，带样式元素数约 −50%；`data-pickthought-range` 移到 `<a>`，注入校验（子串计数）与点击（走 href）均不受影响。
3. `tests/test_epub_inject.lua`：断言改为查 `pickthought-mark` 类令牌（折叠后类落在 `<a>` 上）。

### 验证
真机重注后解剖注入后的 EPUB：`border-bottom=0`、新 `text-decoration` 样式已烘焙、折叠后带样式元素 **7033**（原 14018，约 −50%）；`crash.log` 重注段无 `CRE WARNING` / `Killed`。
