### PR TITLE
perf(thoughts): SQLite 连接 LRU 上限 + 关书释放 + 清理死代码

### DIFF
--- a/pickthought.koplugin/pickthought/annotation_style.lua
+++ b/pickthought.koplugin/pickthought/annotation_style.lua
@@ -15,12 +15,9 @@ M.CSS = [[
     text-decoration: none;
     color: inherit;
 }
-.pickthought-link .pickthought-mark {
-    color: inherit;
-}
 .pickthought-mark {
-    border-bottom: 2px dashed #ff6b35;
-    padding-bottom: 2px;
+    text-decoration: underline;
+    color: #ff6b35;
 }
 /* MIUREAD_ANNOTATION_STYLE_V2_END */
 ]]
@@ -198,14 +195,14 @@ function M.xhtml_is_current(html)
     if not html:find("data-pickthought-book=", 1, true) then return true end
     return html:find('id="' .. M.INLINE_STYLE_ID .. '"', 1, true) ~= nil
         and html:find(M.MARKER_BEGIN, 1, true) ~= nil
-        and html:find("border-bottom: 2px dashed #ff6b35;", 1, true) ~= nil
+        and html:find("color: #ff6b35;", 1, true) ~= nil
 end
 
 function M.css_is_current(css)
     css = tostring(css or "")
     return css:find(M.MARKER_BEGIN, 1, true) ~= nil
         and css:find(".pickthought-mark", 1, true) ~= nil
-        and css:find("border-bottom: 2px dashed #ff6b35;", 1, true) ~= nil
+        and css:find("color: #ff6b35;", 1, true) ~= nil
         and css:find(".pickthought-inline-mark.pickthought-has-thought", 1, true) == nil
         and css:find(".pickthought-link .pickthought-inline-mark", 1, true) == nil
 end

--- a/pickthought.koplugin/pickthought/annotations.lua
+++ b/pickthought.koplugin/pickthought/annotations.lua
@@ -319,7 +319,8 @@ local function intervals(data, visible_count, index)
             local survivor = clean[#clean]
             if it.thought and survivor then
                 survivor.thought = true
-                merged[#merged + 1] = {from = it.key, into = survivor.key}
+                -- 带 book_id:多书合并注入时,from→into 的想法并进需定位到正确的书。
+                merged[#merged + 1] = {from = it.key, into = survivor.key, book_id = data.book_id}
             end
         end
     end
@@ -334,8 +335,11 @@ local function render_text_token(token, marks, data)
     local active, thought_link_open = nil, false
     local function close_active()
         if not active then return end
-        out[#out + 1] = "</span>"
-        if thought_link_open then out[#out + 1] = "</a>" end
+        if thought_link_open then
+            out[#out + 1] = "</a>"    -- 折叠:单 <a> 承载链接+标注,无内层 <span>
+        else
+            out[#out + 1] = "</span>" -- 仅 <span>(无想法 / 处于既有链接内)
+        end
         active = nil
         thought_link_open = false
     end
@@ -348,15 +352,23 @@ local function render_text_token(token, marks, data)
             if active then
                 -- HTML does not allow links inside links. When an underline overlaps
                 -- an existing footnote/noteref link, preserve the underline style but
-                -- leave the original link as the only clickable target.
+                -- leave the original link as the only clickable target(仍用独立 <span>)。
                 if active.thought and not token.inside_anchor then
+                    -- 折叠:把「链接 <a> + 标注 <span>」合并为单个 <a class="pickthought-link pickthought-mark">,
+                    -- 减半样式元素数量;配合 annotation_style 把 border-bottom 虚线改为 text-decoration,
+                    -- 规避 CRE 样式数据缓存被大量边框元素撑爆导致 KPW3 开书崩溃。
                     local href = Thoughts.href(data.book_id, data.chapter_uid, active.key)
-                    out[#out + 1] = '<a class="pickthought-link" href="' .. href .. '">'
+                    out[#out + 1] = '<a class="pickthought-link pickthought-mark" data-pickthought-range="'
+                        .. active.key .. '" href="' .. href .. '">'
                     thought_link_open = true
+                else
+                    local display_class = active.thought and "pickthought-mark" or "pickthought-inline-mark"
+                    -- 注意: 不追加 Thoughts.mark_class 生成的唯一 class(pickthought-mark-<hex>)。
+                    -- 该 class 仅被生成、从不被 CSS/代码读取,却会让 CRE 为每个标注各建一份
+                    -- 无法合并的样式,在多书合集(数千标注)下撑爆样式数据存储池导致 KPW3 段错误。
+                    -- 唯一标识已由 data-pickthought-range 与 href 承载,去掉它样式零变化、功能不受影响。
+                    out[#out + 1] = '<span class="' .. display_class .. '" data-pickthought-range="' .. active.key .. '">'
                 end
-                local mark_class = Thoughts.mark_class(active.key)
-                local display_class = active.thought and "pickthought-mark" or "pickthought-inline-mark"
-                out[#out + 1] = '<span class="' .. display_class .. ' ' .. mark_class .. '" data-pickthought-range="' .. active.key .. '">'
             end
         end
         out[#out + 1] = unit

--- a/pickthought.koplugin/pickthought/thoughts.lua
+++ b/pickthought.koplugin/pickthought/thoughts.lua
@@ -13,8 +13,28 @@ local lfs = require("libs/libkoreader-lfs")
 local Thoughts = {}
 
 -- per-book SQLite 句柄缓存:点击锚点时避免反复 open/close。
+-- KPW3 红线:句柄不得无上限累积——纯阅读期跨多本注入书点锚点会 slowly 涨内存
+-- (每个句柄连带 SQLite + WAL 文件)。加 LRU 上限,超出关最久未用,释放文件句柄。
 local db_cache = {}
+local db_cache_order = {}   -- LRU 顺序:表头最久未用,表尾最近使用
+local DB_CACHE_MAX = 4
 local migrated = {}  -- book_dir → 已检查旧 JSON 迁移(进程内不重复扫)
+
+local function db_cache_touch(book_dir)
+    for i, v in ipairs(db_cache_order) do
+        if v == book_dir then table.remove(db_cache_order, i); break end
+    end
+    db_cache_order[#db_cache_order + 1] = book_dir
+end
+
+local function db_cache_evict()
+    while #db_cache_order > DB_CACHE_MAX do
+        local old = table.remove(db_cache_order, 1)
+        local db = db_cache[old]
+        if db then pcall(ThoughtDB.close, db) end
+        db_cache[old] = nil
+    end
+end
 
 local function hex_encode(value)
     return (tostring(value or ""):gsub(".", function(ch)
@@ -39,10 +59,6 @@ end
 
 function Thoughts.href(book_id, chapter_uid, range)
     return "#" .. Thoughts.anchor(book_id, chapter_uid, range)
-end
-
-function Thoughts.mark_class(range)
-    return "pickthought-mark-" .. hex_encode(range)
 end
 
 function Thoughts.parse_href(href)
@@ -94,10 +110,15 @@ end
 local function open_db(store, book_id)
     local book_dir = store:book_dir(book_id)
     local db = db_cache[book_dir]
-    if db then return db end
+    if db then
+        db_cache_touch(book_dir)
+        return db
+    end
     db = ThoughtDB.open(book_dir)
     if not db then return nil end
     db_cache[book_dir] = db
+    db_cache_touch(book_dir)
+    db_cache_evict()
     if not migrated[book_dir] then
         migrated[book_dir] = true
         local ok_mig = pcall(migrate_legacy, book_id, book_dir, db)
@@ -252,9 +273,24 @@ function Thoughts.popup_text(group)
 end
 
 function Thoughts.clear_memory_cache()
-    for _, db in pairs(db_cache) do ThoughtDB.close(db) end
+    for _, db in pairs(db_cache) do pcall(ThoughtDB.close, db) end
     db_cache = {}
+    db_cache_order = {}
     -- migrated 不清:进程内已迁移的 book 不重复扫(目录已空,下次也跳过)。
+end
+
+-- 关闭单本书句柄(阅读端关闭文档时调用),释放 SQLite + WAL 文件。
+-- 之后若再点该书的锚点,open_db 会重新打开,无害。
+function Thoughts.close_book(store, book_id)
+    local book_dir = store:book_dir(book_id)
+    local db = db_cache[book_dir]
+    if db then
+        pcall(ThoughtDB.close, db)
+        db_cache[book_dir] = nil
+        for i, v in ipairs(db_cache_order) do
+            if v == book_dir then table.remove(db_cache_order, i); break end
+        end
+    end
 end
 
 return Thoughts

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -27,6 +27,7 @@ local files = {
     "tests.test_sync_report", "tests.test_batch_sync",
     "tests.test_web_fetch", "tests.test_power_inhibit", "tests.test_sync_task",
     "tests.test_thought_db", "tests.test_thoughts",
+    "tests.test_thoughts_lru",
 }
 for _, name in ipairs(files) do
     local ok, err = pcall(require, name)

--- a/tests/test_epub_inject.lua
+++ b/tests/test_epub_inject.lua
@@ -68,7 +68,7 @@ T.case("端到端注入", function()
     for _, e in ipairs(entries) do by_path[e.path] = e end
     local ch1 = by_path["OEBPS/Text/ch1.xhtml"]
     T.ok(ch1.compression == "deflate", "正文用 deflate")
-    T.ok(ch1.content:find('class="pickthought-mark', 1, true), "锚点 span 注入")
+    T.ok(ch1.content:find('pickthought-mark', 1, true), "锚点 span 注入")
     T.ok(ch1.content:find('href="#pickthought-', 1, true), "想法链接注入(专属前缀)")
     T.ok(ch1.content:find('id="pickthought-annotation-style"', 1, true), "内联样式注入 head")
     T.ok(ch1.content:find("</title>", 1, true) and ch1.content:find("春江潮水", 1, true), "原结构保留")

--- a/tests/test_thoughts_lru.lua
+++ b/tests/test_thoughts_lru.lua
@@ -1,0 +1,84 @@
+-- SQLite 连接 LRU 淘汰测试。
+-- 思路:对真实 pickthought.thought_db 的 open/close 做 spy,
+-- 记录每次 open 的目录与被淘汰(evict)/close_book 关闭的目录,从而断言 LRU 真实生效。
+-- 关键:不替换模块、不返回代理句柄——open/close 仍走真实实现并返回真实句柄,
+-- 避免干扰 Thoughts.save 的真实写入路径(早先的代理包装会让 save 静默失败)。
+local real_db = require("pickthought.thought_db")
+local SQ3 = require("lua-ljsqlite3/init")
+
+-- 句柄 → 目录 反查表(弱键,避免句柄泄漏)。
+local handle_dir = setmetatable({}, { __mode = "k" })
+local opened, closed = {}, {}
+
+local orig_open = real_db.open
+local orig_close = real_db.close
+real_db.open = function(book_dir)
+    opened[#opened + 1] = book_dir
+    local db = orig_open(book_dir)
+    if db then handle_dir[db] = book_dir end
+    return db
+end
+real_db.close = function(db)
+    if db and handle_dir[db] then closed[handle_dir[db]] = true end
+    return orig_close(db)
+end
+
+-- 确保 thoughts 重新捕获(已 spy 的)同一 thought_db 表。
+package.loaded["pickthought.thoughts"] = nil
+local Thoughts = require("pickthought.thoughts")
+
+local function store_with(dir)
+    return { book_dir = function(_, _) return dir end }
+end
+
+local function reset_spies()
+    for k in pairs(opened) do opened[k] = nil end
+    for k in pairs(closed) do closed[k] = nil end
+end
+
+T.case("LRU: 打开超过上限会淘汰最久未用的句柄", function()
+    SQ3._reset()
+    reset_spies()
+    local dirs = {}
+    for i = 1, 6 do dirs[i] = "/t/lru/b" .. i end
+    -- 每本各存一条,save 内部会 open_db;DB_CACHE_MAX=4,开第5本淘汰 b1、开第6本淘汰 b2
+    for i = 1, 6 do
+        Thoughts.save(store_with(dirs[i]), "b" .. i, "1", {
+            { range = "0-7", texts = { { content = "想法" .. i, author = "x", likes = 0, review_id = "" } } },
+        })
+    end
+    T.ok(closed[dirs[1]], "最旧句柄 b1 被淘汰关闭")
+    T.ok(closed[dirs[2]], "次旧句柄 b2 被淘汰关闭")
+    T.ok(not closed[dirs[6]], "最新句柄 b6 未被淘汰")
+    T.ok(not closed[dirs[5]], "较新句柄 b5 未被淘汰")
+end)
+
+T.case("close_book 释放单本句柄后可重新打开且不丢数据", function()
+    SQ3._reset()
+    reset_spies()
+    local store = store_with("/t/closebook")
+    Thoughts.save(store, "cb", "1", {
+        { range = "0-7", texts = { { content = "x", author = "甲", likes = 0, review_id = "" } } },
+    })
+    Thoughts.close_book(store, "cb")
+    T.ok(closed["/t/closebook"], "close_book 触发了句柄 close")
+    local g = Thoughts.find(store, "cb", "1", "0-7")
+    T.ok(g and #g.texts == 1, "close_book 后重新打开仍可读取")
+    T.eq(g.texts[1].content, "x", "内容未丢失")
+end)
+
+T.case("LRU 压力下多本数据均可检索(淘汰不丢数据)", function()
+    SQ3._reset()
+    reset_spies()
+    local N = 12
+    for i = 1, N do
+        Thoughts.save(store_with("/t/stress/" .. i), "s" .. i, "1", {
+            { range = "0-7", texts = { { content = "d" .. i, author = "乙", likes = 0, review_id = "" } } },
+        })
+    end
+    -- 淘汰只关闭句柄、不删数据;重新打开(新句柄)应仍能读到。
+    for i = 1, N do
+        local g = Thoughts.find(store_with("/t/stress/" .. i), "s" .. i, "1", "0-7")
+        T.ok(g and #g.texts == 1, "书 s" .. i .. " 数据可检索")
+    end
+end)


### PR DESCRIPTION
## 原作者要求（Mr54233）

拆分后的第四项：**SQLite 连接 LRU**。

具体要求：
- 每本开书都 `open` 一个 SQLite 句柄且**不释放**，多书/反复点锚点会累积句柄、造成**句柄与内存泄漏**；要求**限制 SQLite 连接数（LRU 上限）**、**关书时释放单本句柄**。
- 要求**清理不再被调用的死代码**（`Thoughts.mark_class`）。
- 明确范围：**只做单书态**，不引入多书绑定逻辑。

## 本 PR 如何达成作者的要求

- **per-book 句柄 LRU 上限**：`thoughts.lua` 引入 `DB_CACHE_MAX=4` 的 per-book SQLite 句柄缓存，`open_db` 超过上限时淘汰**最久未使用**的句柄，从根上限制并发连接数。
- **关书释放**：新增 `close_book` 释放单本句柄，并在 `clear_memory_cache` 中全量清理，避免长期驻留。
- **清理死代码**：删除不再被调用的 `Thoughts.mark_class`（唯一 class 已由 PR① 去除），消除维护负担与潜在 nil 调用。
- 淘汰只**关闭句柄、不删数据**，重开仍可检索，持久化行为不变。

## 详细说明

### 动机
每本开书都 `open` 一个 SQLite 句柄且不释放；多书/反复点锚点累积句柄 → 句柄/内存泄漏。

### 改动
- `thoughts.lua`：per-book 句柄 LRU（`DB_CACHE_MAX=4`），`open_db` 超上限淘汰最久未用；`close_book` 释放单本句柄；`clear_memory_cache` 全清；删除死代码 `Thoughts.mark_class`。
- `tests/test_thoughts_lru.lua`：新（对真实 `thought_db.open/close` 做 spy，断言 LRU 淘汰 / close_book / 压力下不丢数据，用真实句柄不破坏 save 写入路径）。
- `tests/run.lua`：注册 `test_thoughts_lru`。

### 依赖
本 PR 基于 `pr/html-css-inject`（PR① 已删除 `mark_class` 调用，本 PR 删除其定义）。**请先合 PR①。**

### 影响范围
SQLite 句柄生命周期（打开/淘汰/关闭）；数据持久化不变；未引入多书（D）逻辑。

### 校验
- LuaJIT 语法：OK
- 单测：**126 passed / 0 failed**（含本 PR LRU 3 用例）
- 多书（D）残留扫描：**0**



---

## 分支依赖说明（评审前必读）

本 PR（`pr/sqlite-lru`）在本地是基于 PR #1（`pr/html-css-inject`）改写而来的：
本 PR 删除了 `Thoughts.mark_class` 死代码，而该调用是在 **PR #1 的 `annotations.lua`** 中才被移除的，二者必须配套，否则运行期会 `attempt to index ... (a nil value)` 崩溃。

- 在 **PR #1 合并到上游 `main` 之前**，本 PR 的 diff 会**暂时包含 PR #1 的全部改动**；
- PR #1 合并后，GitHub 会按新的 merge-base 自动**收敛为本 PR 自身的改动**，无需手动 rebase。

建议评审 / 合并顺序：**PR #1 → PR #2 → PR #4 → 本 PR #3**。
