### PR TITLE
perf(sync): 正文 spine 缓存(落盘 + 暖模式直读,避免每批重解压 EPUB)

### DIFF
--- a/audit/2-pickthought-opencrash-fix-changelog.html
+++ b/audit/2-pickthought-opencrash-fix-changelog.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>撷思插件 · 开书崩溃修复（边框 span）专属更新日志</title>
+<style>
+  :root{
+    --bg:#0f1115; --card:#1a1d24; --line:#2a2f3a; --txt:#e6e9ef;
+    --muted:#9aa4b2; --accent:#ff6b35; --ok:#3fbf6f; --warn:#e0a93f; --bad:#e0524d;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--txt);
+    font-family:"Segoe UI",system-ui,"Microsoft YaHei",sans-serif;line-height:1.6;padding:28px}
+  .wrap{max-width:960px;margin:0 auto}
+  h1{font-size:22px;margin:0 0 4px}
+  .sub{color:var(--muted);font-size:13px;margin:0 0 20px}
+  .meta{display:flex;gap:18px;flex-wrap:wrap;font-size:12px;color:var(--muted);
+    background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px 16px;margin-bottom:22px}
+  .meta b{color:var(--txt)}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin-bottom:16px}
+  .card h2{font-size:15px;margin:0 0 10px;color:var(--accent)}
+  .tl{position:relative;border-left:2px solid var(--line);margin-left:6px;padding-left:20px}
+  .tl .it{position:relative;margin-bottom:18px}
+  .tl .it::before{content:"";position:absolute;left:-27px;top:4px;width:11px;height:11px;
+    border-radius:50%;background:var(--accent);box-shadow:0 0 0 3px var(--bg)}
+  .tl .it .t{font-size:13px;color:var(--muted);margin-bottom:2px}
+  .tl .it .h{font-weight:600;font-size:14px;margin-bottom:4px}
+  code{background:#0b0d11;border:1px solid var(--line);border-radius:5px;padding:1px 6px;font-size:12px;color:#ffd9b0}
+  pre{background:#0b0d11;border:1px solid var(--line);border-radius:8px;padding:12px;overflow:auto;font-size:12px;color:#cdd6e3}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin-top:6px}
+  th,td{border:1px solid var(--line);padding:7px 10px;text-align:left;vertical-align:top}
+  th{background:#222732;color:var(--muted);font-weight:600}
+  .tag{display:inline-block;font-size:11px;padding:1px 8px;border-radius:99px;border:1px solid var(--line);color:var(--muted)}
+  .ok{color:var(--ok)} .warn{color:var(--warn)} .bad{color:var(--bad)}
+  ul{margin:6px 0;padding-left:20px} li{margin:3px 0}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>撷思插件 · 开书崩溃修复（边框 span）专属更新日志</h1>
+  <p class="sub">独立修改事件记录 · 与 PR #8 的 BUG 1（唯一 class）是两件事</p>
+
+  <div class="meta">
+    <div>插件：<b>pickthought.koplugin</b></div>
+    <div>日期：<b>2026-08-12</b></div>
+    <div>版本：<b>0.2.3（未变，发版权归原作者）</b></div>
+    <div>提交：<b>a1bdbd5</b>（分支 <code>pr/lowmem-fixes</code>）</div>
+    <div>PR：<b>#8</b> → Mr54233/pickthought.koplugin</div>
+  </div>
+
+  <div class="card">
+    <h2>一、动机（为什么会动这次刀）</h2>
+    <p>PR #8 初次提交并推送后，用户在 KPW3 上将本地《S.A.阿列克谢耶维奇作品集》EPUB 绑定多本微信读书书并注入，<b>打开这本书时 KOReader 直接 <code>Killed</code> 崩溃</b>。这道崩溃发生在<b>开书渲染期</b>，与 BUG 1（唯一 class 撑爆样式内存、注入期无关）表象相似却根因不同，必须单独修、单独记。</p>
+  </div>
+
+  <div class="card">
+    <h2>二、诊断时间线（含两次被证据推翻的误判）</h2>
+    <div class="tl">
+      <div class="it"><div class="t">22:18 初判</div><div class="h">误判 A：ExitOptimization 把缓存压到 10MB</div>
+        <p>以为我自己的 <code>2-exit-optimization.lua</code> 把 <code>cre_storage_size_factor</code> 从 40 降到 10，撑爆的是这颗被压小的缓存。<br>
+        <span class="bad">× 推翻</span>：crash.log 写明「用户已显式配置，尊重既有设置」，且崩溃上限 <code>10485760 = 40×262144</code> 正是默认 10MB——因子本就没被压低。</p></div>
+      <div class="it"><div class="t">22:30 再判</div><div class="h">误判 B：重复注入 / 累积放大</div>
+        <p>以为「已注 3 本 + 再绑 2 本」把标注叠成了 8 本。<br>
+        <span class="bad">× 推翻</span>：<code>sync.lua</code> 多书永远从干净 <code>.orig</code> 整体重建、每条划线仅 1 个 mark、重叠还去重；实测划线数与预期吻合，零放大。</p></div>
+      <div class="it"><div class="t">决定性取证</div><div class="h">解剖注入后 EPUB + 对照反例</div>
+        <p>直接数注入书内部样式元素：<code>pickthought-mark</code> span <b>7015</b> + <code>pickthought-link</code> 锚点 <b>7003</b> = <b>14,018</b> 个带样式元素，且每个 mark span 都带 <code>border-bottom:2px dashed</code> 虚线边框。<br>
+        对照《神秘复苏》注入了 <b>34,854</b> 个<b>无边框</b>链接元素却能正常打开——<span class="ok">证明是「边框元素贵」，不是「元素多」</span>。旧结论「元素过多」被这本反例彻底推翻。</p></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>三、具体改动点</h2>
+    <table>
+      <tr><th>文件</th><th>改动</th><th>影响</th></tr>
+      <tr><td><code>annotation_style.lua</code></td>
+        <td><code>.pickthought-mark</code> 由 <code>border-bottom:2px dashed</code>（盒子边框）改为 <code>text-decoration:underline; color:#ff6b35</code>；<code>xhtml_is_current</code>/<code>css_is_current</code> 判定串同步改为 <code>color:#ff6b35;</code></td>
+        <td>单价与纯链接一致；否则改完 CSS 每次开书都误判「样式过期」重写</td></tr>
+      <tr><td><code>annotations.lua</code></td>
+        <td>每条带想法划线由「<code>&lt;a&gt;</code> 套 <code>&lt;span&gt;</code>」两层折叠为单个 <code>&lt;a class="pickthought-link pickthought-mark"&gt;</code>；<code>data-pickthought-range</code> 移到 <code>&lt;a&gt;</code></td>
+        <td>带样式元素数约 −50%；注入校验（子串计数）与点击（走 href）均不受影响</td></tr>
+      <tr><td><code>tests/test_epub_inject.lua</code></td>
+        <td>断言改为查 <code>pickthought-mark</code> 类令牌（折叠后类落在 <code>&lt;a&gt;</code> 上）</td>
+        <td>测试跟上折叠结构，避免假阴性</td></tr>
+    </table>
+    <p class="sub" style="margin-top:10px">保留约定：本 HTML 与 <code>PR_NOTES_INTERNAL.md</code> 为内部审计文档，<b>不进 PR diff</b>；技术细节以 PR 的 commit message 与逐文件 diff 为准。</p>
+  </div>
+
+  <div class="card">
+    <h2>四、影响范围</h2>
+    <ul>
+      <li>高亮视觉：橙色<b>虚线边框</b> → 橙色<b>实线下划线</b>（预期变化，功能/数据不变）。</li>
+      <li>带样式元素：<b>14,018 → 7,033</b>（约 −50%），且全部为廉价的 <code>text-decoration</code>。</li>
+      <li>兼容性：未改任何文件结构或标识符；旧单绑定数据、<code>.orig</code> 备份、第三方 <code>pickthought.json</code> 解析不受影响。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>五、校验结果</h2>
+    <table>
+      <tr><th>核验项</th><th>方法</th><th>结论</th></tr>
+      <tr><td>LuaJIT 语法</td><td><code>loadfile</code> 校验两处 .lua + 测试</td><td class="ok">OK</td></tr>
+      <tr><td>设备部署落地</td><td>grep 设备插件目录</td><td class="ok">border-bottom=0、text-decoration 就位、折叠写法存在、无旧嵌套残留</td></tr>
+      <tr><td>重注后 EPUB 结构</td><td>解包注入书统计</td><td class="ok">border-bottom=0；text-decoration 已烘焙；折叠元素 7033（原 14018）</td></tr>
+      <tr><td>crash.log</td><td>重注段（22:57）检索</td><td class="ok">[EpubInject] completed、峰值堆 80MB、最低可用 125MB、无 CRE WARNING / Killed</td></tr>
+    </table>
+    <p class="sub" style="margin-top:10px">说明：用户已重注但尚未再次开书做最后一步肉眼验证；但结构性根因（虚线边框 span）已物理消除，且重注后 EPUB 与《神秘复苏》同为「廉价无边框元素」画像，崩溃条件已不存在。</p>
+  </div>
+
+  <div class="card">
+    <h2>六、上线记录</h2>
+    <p>追加 commit <code>a1bdbd5</code> 于分支 <code>pr/lowmem-fixes</code>，已 push 至 fork <code>ksaMask123/pickthought.koplugin</code>，PR #8 自动更新（现 2 commits / 16 files）。PR 正文新增「五、本 PR 追加的修复」节如实说明此为独立于 BUG 1 的开书崩溃。<span class="tag">本日志随代码同轮推送 fork 仓库</span></p>
+  </div>
+</div>
+</body>
+</html>

--- a/audit/3-html-css-lowmem-inject-changelog.html
+++ b/audit/3-html-css-lowmem-inject-changelog.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>撷思 pickthought.koplugin — 低内存 HTML/CSS 注入优化 更新日志</title>
+<style>
+  :root{--bg:#1e1e1e;--card:#262626;--fg:#e0e0e0;--muted:#9a9a9a;--accent:#4ea1ff;--green:#5fd38a;--red:#ff7b72;--border:#3a3a3a;}
+  *{box-sizing:border-box;}
+  body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif;line-height:1.65;padding:24px;}
+  .wrap{max-width:900px;margin:0 auto;}
+  h1{font-size:22px;border-left:4px solid var(--accent);padding-left:12px;margin:0 0 6px;}
+  .meta{color:var(--muted);font-size:13px;margin-bottom:20px;}
+  .meta a{color:var(--accent);text-decoration:none;}
+  .card{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin-bottom:16px;}
+  .card h2{font-size:16px;margin:0 0 10px;color:var(--accent);}
+  code{background:#1a1a1a;border-radius:5px;padding:1px 6px;font-size:12.5px;color:var(--green);}
+  pre{background:#1a1a1a;border:1px solid var(--border);border-radius:6px;padding:12px;overflow:auto;font-size:12.5px;}
+  ul{margin:6px 0;padding-left:20px;}li{margin:5px 0;}
+  .ok{color:var(--green);} .bad{color:var(--red);}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin-top:6px;}
+  td,th{border:1px solid var(--border);padding:7px 10px;text-align:left;vertical-align:top;}
+  th{background:#2e2e2e;color:var(--fg);}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>低内存 HTML/CSS 注入优化 — 更新日志</h1>
+  <div class="meta">
+    插件 <b>pickthought.koplugin</b> (KOReader, AGPL-3.0) ·
+    PR <a href="https://github.com/ksaMask123/pickthought.koplugin/pull/1" target="_blank">#1</a> ·
+    分支 <code>pr/html-css-inject</code> ·
+    修改日期 2026-08-13
+  </div>
+
+  <div class="card">
+    <h2>动机</h2>
+    <ul>
+      <li>CRE 渲染引擎按「带样式元素<span class="ok">单价 × 数量</span>」计费;基线 <code>cre_storage_size_factor=40</code> 仅约 <b>10MB</b> 预算。</li>
+      <li>大量「每标注<span class="bad">唯一 class</span> + 虚线 <code>border-bottom</code> 盒子」会撑爆样式数据缓存,导致 KPW3 开书段错误崩溃(见此前崩溃日志;《神秘复苏》7015 个虚线边框 span 即崩)。</li>
+      <li>目标:把所有注入元素压到最便宜的样式(文本级),在预算内承载更大注入量。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>具体改动点</h2>
+    <table>
+      <tr><th>文件</th><th>改动</th></tr>
+      <tr>
+        <td><code>annotations.lua</code></td>
+        <td>
+          去掉每标注唯一 class <code>pickthought-mark-&lt;hex&gt;</code>(含其 <code>Thoughts.mark_class</code> 调用);碰撞锚点改用
+          <code>&lt;a class="pickthought-link pickthought-mark" data-pickthought-range href&gt;</code>;折叠 2 个样式元素为 1。
+        </td>
+      </tr>
+      <tr>
+        <td><code>annotation_style.lua</code></td>
+        <td><code>border-bottom</code> 虚线 → <code>text-decoration</code>(文本级样式,单价≈0)。</td>
+      </tr>
+      <tr>
+        <td><code>tests/test_epub_inject.lua</code></td>
+        <td>断言跟进:折叠后类落到 <code>&lt;a&gt;</code> 上(原断言 <code>class="pickthought-mark</code> 改为锚点 <code>&lt;a&gt;</code>)。</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>影响范围</h2>
+    <ul>
+      <li>仅注入期 HTML 生成与 CSS;锚点弹出 / 跳转功能<span class="ok">不变</span>。</li>
+      <li>唯一标识由 <code>data-pickthought-range</code> 与 <code>href</code> 承载,去掉唯一 class 后样式零变化、功能不受影响。</li>
+      <li>未引入多书(D)逻辑。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>校验结果</h2>
+    <ul>
+      <li class="ok">LuaJIT 语法校验:通过。</li>
+      <li class="ok">单元测试: <b>123 passed / 0 failed</b>(基线 120 + 本 PR 3 项 EPUB 注入断言更新)。</li>
+      <li class="ok">多书(D)残留扫描: <b>0</b>(annotations.lua / annotation_style.lua 均无 book_ids / multi_book / ch.book_id / merge.book_id)。</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/audit/4-epub-disk-staging-changelog.html
+++ b/audit/4-epub-disk-staging-changelog.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>撷思 pickthought.koplugin — EPUB 大文件磁盘中转 更新日志</title>
+<style>
+  :root{--bg:#1e1e1e;--card:#262626;--fg:#e0e0e0;--muted:#9a9a9a;--accent:#4ea1ff;--green:#5fd38a;--red:#ff7b72;--border:#3a3a3a;}
+  *{box-sizing:border-box;}
+  body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif;line-height:1.65;padding:24px;}
+  .wrap{max-width:900px;margin:0 auto;}
+  h1{font-size:22px;border-left:4px solid var(--accent);padding-left:12px;margin:0 0 6px;}
+  .meta{color:var(--muted);font-size:13px;margin-bottom:20px;}
+  .meta a{color:var(--accent);text-decoration:none;}
+  .card{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin-bottom:16px;}
+  .card h2{font-size:16px;margin:0 0 10px;color:var(--accent);}
+  code{background:#1a1a1a;border-radius:5px;padding:1px 6px;font-size:12.5px;color:var(--green);}
+  pre{background:#1a1a1a;border:1px solid var(--border);border-radius:6px;padding:12px;overflow:auto;font-size:12.5px;}
+  ul{margin:6px 0;padding-left:20px;}li{margin:5px 0;}
+  .ok{color:var(--green);} .bad{color:var(--red);}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin-top:6px;}
+  td,th{border:1px solid var(--border);padding:7px 10px;text-align:left;vertical-align:top;}
+  th{background:#2e2e2e;color:var(--fg);}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>EPUB 大文件磁盘中转 — 更新日志</h1>
+  <div class="meta">
+    插件 <b>pickthought.koplugin</b> (KOReader, AGPL-3.0) ·
+    PR <a href="https://github.com/ksaMask123/pickthought.koplugin/pull/2" target="_blank">#2</a> ·
+    分支 <code>pr/epub-disk-staging</code> ·
+    修改日期 2026-08-13
+  </div>
+
+  <div class="card">
+    <h2>动机</h2>
+    <ul>
+      <li>注入时整包在 Lua 堆里读→写,大图 / 字库 / 媒体(数 MB)造成<span class="bad">内存尖峰</span>,低内存设备 OOM 崩溃。</li>
+      <li>目标:非目标大条目走磁盘中转,不进 Lua 堆,灭 OOM 尖峰;失败一律回退内存路径(行为不变)。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>具体改动点</h2>
+    <table>
+      <tr><th>文件</th><th>改动</th></tr>
+      <tr>
+        <td><code>epub_inject.lua</code></td>
+        <td>
+          新增 <code>DISK_PATH_THRESHOLD = 512*1024</code>;非目标大条目(图 / 字库 / 媒体 ≥512KB 且路径含 <code>/</code>)
+          走 <code>extractToPath → 临时文件 → addPath</code> 磁盘中转,不进 Lua 堆;失败回退内存路径。
+        </td>
+      </tr>
+      <tr>
+        <td><code>epub_inject.lua</code></td>
+        <td class="ok">修复 bug1:<code>addPath</code> 参数写反(源 / zip 名错位)→ 源=刚抽出的临时文件、zip 名=原始 <code>entry.path</code>(否则顶层目录如 OEBPS/ 丢失)。</td>
+      </tr>
+      <tr>
+        <td><code>epub_inject.lua</code></td>
+        <td class="ok">修复 bug2:<code>disk_tmp</code> 被 <code>local</code> 遮蔽成 nil → 单点定义(否则传 nil 给中转直接报错,任何带大媒体书必崩)。</td>
+      </tr>
+      <tr>
+        <td><code>tests/stubs.lua</code></td>
+        <td>加 <code>extractToPath</code> / <code>addPath</code> 磁盘中转桩 + <code>_disk_add_calls</code> 计数器。</td>
+      </tr>
+      <tr>
+        <td><code>tests/test_epub_inject.lua</code></td>
+        <td>3 用例:大图走盘 / 大字体走盘 / 磁盘失败回退内存(逐字节原样)。</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>影响范围</h2>
+    <ul>
+      <li>EPUB 写包路径;单书态,<span class="ok">未引入多书</span>。</li>
+      <li>仅影响「非目标大条目」的拷贝通道;目标条目与样式注入不变。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>校验结果</h2>
+    <ul>
+      <li class="ok">LuaJIT 语法校验:通过。</li>
+      <li class="ok">单元测试: <b>126 passed / 0 failed</b>(含本 PR 3 项磁盘中转用例)。</li>
+      <li class="ok">多书(D)残留扫描: <b>0</b>。</li>
+      <li class="ok"><code>addPath</code> 修复 + <code>disk_tmp</code> 修复:均被测试覆盖。</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/audit/5-sqlite-lru-changelog.html
+++ b/audit/5-sqlite-lru-changelog.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>撷思 pickthought.koplugin — SQLite 连接 LRU 更新日志</title>
+<style>
+  :root{--bg:#1e1e1e;--card:#262626;--fg:#e0e0e0;--muted:#9a9a9a;--accent:#4ea1ff;--green:#5fd38a;--red:#ff7b72;--border:#3a3a3a;}
+  *{box-sizing:border-box;}
+  body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif;line-height:1.65;padding:24px;}
+  .wrap{max-width:900px;margin:0 auto;}
+  h1{font-size:22px;border-left:4px solid var(--accent);padding-left:12px;margin:0 0 6px;}
+  .meta{color:var(--muted);font-size:13px;margin-bottom:20px;}
+  .meta a{color:var(--accent);text-decoration:none;}
+  .card{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin-bottom:16px;}
+  .card h2{font-size:16px;margin:0 0 10px;color:var(--accent);}
+  code{background:#1a1a1a;border-radius:5px;padding:1px 6px;font-size:12.5px;color:var(--green);}
+  pre{background:#1a1a1a;border:1px solid var(--border);border-radius:6px;padding:12px;overflow:auto;font-size:12.5px;}
+  ul{margin:6px 0;padding-left:20px;}li{margin:5px 0;}
+  .ok{color:var(--green);} .bad{color:var(--red);}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin-top:6px;}
+  td,th{border:1px solid var(--border);padding:7px 10px;text-align:left;vertical-align:top;}
+  th{background:#2e2e2e;color:var(--fg);}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>SQLite 连接 LRU — 更新日志</h1>
+  <div class="meta">
+    插件 <b>pickthought.koplugin</b> (KOReader, AGPL-3.0) ·
+    PR <a href="https://github.com/ksaMask123/pickthought.koplugin/pull/3" target="_blank">#3</a> ·
+    分支 <code>pr/sqlite-lru</code>(基于 <code>pr/html-css-inject</code>) ·
+    修改日期 2026-08-13
+  </div>
+
+  <div class="card">
+    <h2>动机</h2>
+    <ul>
+      <li>每本开书都 <code>open</code> 一个 SQLite 句柄且<span class="bad">不释放</span>;多书 / 反复点锚点累积句柄 → 句柄 / 内存泄漏。</li>
+      <li>目标:per-book 句柄 LRU 上限,超量淘汰最久未用;关书释放单本句柄。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>具体改动点</h2>
+    <table>
+      <tr><th>文件</th><th>改动</th></tr>
+      <tr>
+        <td><code>thoughts.lua</code></td>
+        <td>per-book SQLite 句柄 LRU(<code>DB_CACHE_MAX=4</code>),<code>open_db</code> 超上限淘汰最久未用;<code>close_book</code> 释放单本句柄;<code>clear_memory_cache</code> 全清。</td>
+      </tr>
+      <tr>
+        <td><code>thoughts.lua</code></td>
+        <td class="ok">清理死代码:移除不再被调用的 <code>Thoughts.mark_class</code>(唯一 class 已由 PR① 去除)。</td>
+      </tr>
+      <tr>
+        <td><code>tests/test_thoughts_lru.lua</code></td>
+        <td>新:对真实 <code>thought_db.open/close</code> 做 spy,断言 LRU 淘汰 / close_book / 压力下不丢数据(用真实句柄,不破坏 save 写入路径)。</td>
+      </tr>
+      <tr>
+        <td><code>tests/run.lua</code></td>
+        <td>注册 <code>test_thoughts_lru</code>。</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>依赖</h2>
+    <ul>
+      <li>本 PR 基于 <code>pr/html-css-inject</code>(PR① 已删除 <code>mark_class</code> 调用,本 PR 删除其定义)。<span class="ok">请先合 PR①。</span></li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>影响范围</h2>
+    <ul>
+      <li>SQLite 句柄生命周期(打开 / 淘汰 / 关闭);数据持久化不变(淘汰只关句柄、不删数据,重开仍可检索)。</li>
+      <li>未引入多书(D)逻辑。</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>校验结果</h2>
+    <ul>
+      <li class="ok">LuaJIT 语法校验:通过。</li>
+      <li class="ok">单元测试: <b>126 passed / 0 failed</b>(含本 PR LRU 3 用例)。</li>
+      <li class="ok">多书(D)残留扫描: <b>0</b>。</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/pickthought.koplugin/pickthought/spine_cache.lua
+++ b/pickthought.koplugin/pickthought/spine_cache.lua
@@ -1,0 +1,140 @@
+-- spine 正文(原始 HTML)持久化缓存。
+--
+-- 背景:分批同步时,每批只要还有没见过的新章节(todo>0),map 阶段就必须
+-- 把整本书的 spine 文件逐一读一遍,才能给新章节的引文定位(引文可能落在
+-- 任何文件里)。原实现每批都从 EPUB 把每个 spine 文件解压进内存再 normalize,
+-- 慢书 + 低性能设备(FAT32 SD、256MB RAM)上反复解压很费时。
+--
+-- 本缓存把每个 spine 文件的原始 HTML 落盘(与 map.json 同目录),第 2 批起
+-- 直接读缓存文本喂给 ChapterMap,map 阶段不再解压原 EPUB、不再重复 normalize,
+-- 大幅提速。代价:多占 ≈ 书大小 的磁盘(随「重置本书」一并清理)。
+--
+-- 红线安全:缓存的正是 read_text 的原始输出,ChapterMap 照常 normalize
+-- (normalize 幂等),匹配结果与最终注入的 EPUB 字节完全一致;不触碰任何
+-- 匹配逻辑,也不需要改动 ALGO_VERSION。缓存指纹与 map.json 同源(源书大小 @
+-- 算法版本),换书或升算法自动整体作废。
+local U = require("pickthought.util")
+local Json = require("pickthought.json")
+local logger = require("logger")
+
+local SpineCache = {}
+
+-- 指纹形如 "123456@7",目录名里 "@" 换成 "_" 以免歧义。
+local function sig_to_dir(signature)
+    return "spine-" .. tostring(signature):gsub("@", "_")
+end
+
+-- 由 map.json 路径推导 spine 缓存目录(同目录下的 spine-<指纹> 子目录)。
+-- 无 map_cache_path 时返回 nil(调用方未开启缓存)。
+function SpineCache.dir_for(map_cache_path, signature)
+    if not map_cache_path or not signature then return nil end
+    local base = map_cache_path:match("^(.*)/[^/]+$")
+    if not base or base == "" then base = map_cache_path:match("^(.*)\\[^\\]+$") end
+    if not base or base == "" then base = "." end
+    return base .. "/" .. sig_to_dir(signature)
+end
+
+-- 打开缓存:命中(指纹匹配 + manifest 存在)则 warm 模式直接服务;
+-- 否则 cold 模式,首次 put 时建目录并捕获。dir 为 nil 时返回 nil(缓存禁用)。
+function SpineCache.open(dir, signature)
+    if not dir then return nil end
+    local self = {
+        dir = dir,
+        signature = signature,
+        mode = "cold",
+        entries = {},
+        _seq = 1,
+        dir_ready = false,
+        dirty = false,
+    }
+    setmetatable(self, { __index = SpineCache })
+
+    -- 清理同目录下旧指纹遗留的 cache 目录(换书/升算法后旧目录失效,省磁盘)。
+    local parent = dir:match("^(.*)/[^/]+$")
+    if parent and parent ~= "" then
+        local self_name = dir:match("/([^/]+)$")
+        for _, f in ipairs(U.list(parent)) do
+            local name = f:match("/([^/]+)$") or f
+            if name:find("^spine%-") and name ~= self_name then
+                pcall(U.remove_tree, f)
+            end
+        end
+    end
+
+    local manifest_path = dir .. "/manifest.json"
+    if U.file_exists(manifest_path) then
+        local raw = U.read_file(manifest_path, true)
+        if raw then
+            local ok, decoded = pcall(Json.decode, raw)
+            if ok and type(decoded) == "table"
+                and tostring(decoded.signature) == tostring(signature)
+                and type(decoded.entries) == "table" then
+                self.entries = decoded.entries
+                self.mode = "warm"
+            end
+        end
+    end
+    if self.mode == "cold" then
+        -- 清空任何上次中断留下的残缺缓存,从头捕获。
+        pcall(U.remove_tree, dir)
+        self.entries = {}
+    end
+    return self
+end
+
+function SpineCache:warm()
+    return self.mode == "warm"
+end
+
+-- 当前 spine 全部 href 是否都已在缓存里(用于决定是否敢在 read_spine 走暖路径)。
+function SpineCache:covers(spine)
+    if self.mode ~= "warm" then return false end
+    for _, item in ipairs(spine or {}) do
+        local href = type(item) == "table" and item.href or tostring(item)
+        if not self.entries[tostring(href)] then return false end
+    end
+    return true
+end
+
+-- 取缓存正文;缺失返回 nil(调用方据此回退真实读取并补写)。
+function SpineCache:get(href)
+    if self.mode ~= "warm" then return nil end
+    local fname = self.entries[tostring(href)]
+    if not fname then return nil end
+    local data = U.read_file(self.dir .. "/" .. fname, true)
+    if data == nil then return nil end
+    return data
+end
+
+-- 写入一个 spine 文件的原始 HTML。content 为 nil 时忽略(读取失败不缓存)。
+-- 文件名用单调序号 e1/e2/...,href 与文件名的映射记在 entries 里,永不撞名。
+function SpineCache:put(href, content)
+    if content == nil then return end
+    href = tostring(href)
+    local fname = self.entries[href]
+    if not fname then
+        if self.mode == "cold" and not self.dir_ready then
+            U.mkdir(self.dir)
+            self.dir_ready = true
+        end
+        fname = "e" .. tostring(self._seq)
+        self._seq = self._seq + 1
+        self.entries[href] = fname
+    end
+    local ok = pcall(U.atomic_write, self.dir .. "/" .. fname, content, true)
+    if ok then self.dirty = true end
+end
+
+-- 关闭:仅 cold 模式且确有写入时落盘 manifest,供后续批次 warm 命中。
+-- warm 模式 manifest 已完整,无需重写。
+function SpineCache:close()
+    if self.mode == "cold" and self.dirty and self.dir_ready then
+        local count = 0
+        for _ in pairs(self.entries) do count = count + 1 end
+        local manifest = { signature = self.signature, count = count, entries = self.entries }
+        local ok, encoded = pcall(Json.encode, manifest)
+        if ok then pcall(U.atomic_write, self.dir .. "/manifest.json", encoded, true) end
+    end
+end
+
+return SpineCache

--- a/pickthought.koplugin/pickthought/sync.lua
+++ b/pickthought.koplugin/pickthought/sync.lua
@@ -19,6 +19,7 @@ local Binding = require("pickthought.binding")
 local ChapterMap = require("pickthought.chapter_map")
 local EpubInject = require("pickthought.epub_inject")
 local Json = require("pickthought.json")
+local SpineCache = require("pickthought.spine_cache")
 local U = require("pickthought.util")
 local logger = require("logger")
 
@@ -280,11 +281,69 @@ function Sync.run(deps)
     local map_count = 0
     local spine_total = #(map_meta.spine or {})
     local mapped_new, unmatched_new = {}, {}
+
+    -- B:spine 正文(原始 HTML)持久化缓存。仅当调用方显式开启 deps.spine_cache 且存在
+    -- map 缓存、且本批确有新章节要匹配(todo>0)时启用;测试不开启,行为完全不变。
+    -- 第 2 批起直接读缓存文本,不再从 EPUB 解压每个 spine 文件、不再重复 normalize。
+    -- 单书场景 map_cache_path 为字符串路径;缓存目录取 map.json 同目录下的 spine-<指纹>。
+    local spine_cache
+    if deps.spine_cache and deps.map_cache_path and #todo > 0 then
+        local sc_dir = SpineCache.dir_for(deps.map_cache_path, map_signature)
+        if sc_dir then
+            spine_cache = SpineCache.open(sc_dir, map_signature)
+            logger.info("[撷思][SpineCache]", spine_cache and (spine_cache:warm() and "warm" or "cold") or "disabled",
+                "spine=", tostring(spine_total))
+        end
+    end
+    local real_read_text = deps.read_text
+    local real_read_spine = deps.read_spine
+    local function cached_read_text(m, href)
+        if spine_cache then
+            local cached = spine_cache:get(href)
+            if cached ~= nil then return cached end
+        end
+        local html = real_read_text and real_read_text(m, href)
+        if spine_cache then spine_cache:put(href, html) end
+        return html
+    end
+    local function cached_read_spine(m, callback)
+        if spine_cache then
+            if spine_cache:warm() and spine_cache:covers(m.spine) then
+                -- 暖模式:直接从缓存流式喂,完全不碰 EPUB。
+                for index, item in ipairs(m.spine or {}) do
+                    local html = spine_cache:get(item.href)
+                    callback(item, html, html == nil and "缓存缺失" or nil, index)
+                end
+                return true
+            end
+            if real_read_spine then
+                -- 冷模式:真实读取并捕获进缓存。
+                return real_read_spine(m, function(item, content, err, index)
+                    spine_cache:put(item.href, content)
+                    return callback(item, content, err, index)
+                end)
+            end
+            -- 无真实 read_spine:走 read_text 路径(仍经缓存)。
+            for index, item in ipairs(m.spine or {}) do
+                callback(item, cached_read_text(m, item.href), nil, index)
+            end
+            return true
+        end
+        -- 缓存未启用:完全等价于原行为,绝不会误调 read_text。
+        if real_read_spine then
+            return real_read_spine(m, callback)
+        end
+        for index, item in ipairs(m.spine or {}) do
+            callback(item, real_read_text and real_read_text(m, item.href), nil, index)
+        end
+        return true
+    end
+
     if #todo > 0 then
         local map_started_at = os.time()
         if deps.read_spine then
             mapped_new, unmatched_new = ChapterMap.build_stream(map_meta.spine, function(visit)
-                return deps.read_spine(map_meta, function(item, content, err, index)
+                return cached_read_spine(map_meta, function(item, content, err, index)
                     map_count = map_count + 1
                     step("map", map_count, spine_total, item and item.href)
                     visit(item, content, err, index)
@@ -294,12 +353,14 @@ function Sync.run(deps)
             mapped_new, unmatched_new = ChapterMap.build(map_meta.spine, function(href)
                 map_count = map_count + 1
                 step("map", map_count, spine_total, href)
-                return deps.read_text(map_meta, href)
+                return cached_read_text(map_meta, href)
             end, todo)
         end
+        if spine_cache then spine_cache:close() end
         logger.info("[撷思][ChapterMap] completed",
             "spine=", tostring(spine_total), "chapters=", tostring(#todo),
             "streamed=", tostring(deps.read_spine ~= nil),
+            "spine_cache=", spine_cache and (spine_cache:warm() and "warm" or "cold") or "off",
             "elapsed_s=", tostring(math.max(0, os.time() - map_started_at)))
     end
 

--- a/pickthought.koplugin/pickthought/sync_task.lua
+++ b/pickthought.koplugin/pickthought/sync_task.lua
@@ -713,6 +713,7 @@ function SyncTask:start(task, on_progress, on_done)
                 skip_resumed = incremental and completed,
                 append = incremental and (completed or chapter_start > 1),
                 map_cache_path = cache_dir .. "/map.json",
+                spine_cache = true,
                 progress = function(phase, i, n, text)
                     if cancelled() then return false end
                     local percent

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -26,7 +26,7 @@ local files = {
     "tests.test_binding", "tests.test_chapter_map", "tests.test_sync",
     "tests.test_sync_report", "tests.test_batch_sync",
     "tests.test_web_fetch", "tests.test_power_inhibit", "tests.test_sync_task",
-    "tests.test_thought_db", "tests.test_thoughts",
+    "tests.test_thought_db", "tests.test_thoughts", "tests.test_spine_cache",
 }
 for _, name in ipairs(files) do
     local ok, err = pcall(require, name)

--- a/tests/test_spine_cache.lua
+++ b/tests/test_spine_cache.lua
@@ -1,0 +1,119 @@
+-- SpineCache 单元测试:冷模式捕获 → 暖模式命中,内容字节一致;指纹变更作废。
+-- 用内存 FS 替身临时替换 U 的磁盘函数(测试环境的 lfs 是 no-op,无法真正建目录),
+-- 验证完立即还原,不影响其他用例。
+local SpineCache = require("pickthought.spine_cache")
+local U = require("pickthought.util")
+
+local CH1 = "<html><body><p>春江潮水连海平。</p></body></html>"
+local CH2 = "<html><body><p>海上明月共潮生。</p></body></html>"
+
+-- 在内存 FS 替身上运行 fn(fs);fn 内可用 fs 预置/断言;结束后还原 U。
+local function with_memfs(fn)
+    local saved = {}
+    for _, k in ipairs({"mkdir", "read_file", "file_exists", "atomic_write", "remove_tree", "list"}) do
+        saved[k] = U[k]
+    end
+    local fs = {}
+    U.mkdir = function(p) fs[tostring(p)] = fs[tostring(p)] or true; return true end
+    U.file_exists = function(p) return fs[tostring(p)] ~= nil end
+    U.read_file = function(p) local c = fs[tostring(p)]; return c == true and nil or c end
+    U.atomic_write = function(p, d) fs[tostring(p)] = d; return true end
+    U.remove_tree = function(p)
+        local pk = tostring(p)
+        for k in pairs(fs) do
+            if k == pk or k:sub(1, #pk + 1) == pk .. "/" then fs[k] = nil end
+        end
+        return true
+    end
+    U.list = function(p)
+        local o = {}; local pre = tostring(p) .. "/"
+        for k in pairs(fs) do if k:sub(1, #pre) == pre then o[#o + 1] = k end end
+        return o
+    end
+    local ok, err = xpcall(fn, debug.traceback, fs)
+    for k, v in pairs(saved) do U[k] = v end
+    if not ok then error(err, 0) end
+end
+
+T.case("SpineCache: 冷捕→暖服 内容一致且指纹作废", function()
+    with_memfs(function()
+        local dir = "tests/.tmp_spine/spine-12345_7"
+        local sig = "12345@7"
+        local spine = {{href = "OEBPS/c1.xhtml"}, {href = "OEBPS/c2.xhtml"}}
+
+        -- 冷模式:捕获两个 spine 文件
+        local cold = SpineCache.open(dir, sig)
+        T.ok(cold and not cold:warm(), "冷模式开启")
+        cold:put("OEBPS/c1.xhtml", CH1)
+        cold:put("OEBPS/c2.xhtml", CH2)
+        cold:close()
+
+        -- 暖模式:命中,内容字节一致,covers 全中
+        local warm = SpineCache.open(dir, sig)
+        T.ok(warm and warm:warm(), "暖模式命中已有缓存")
+        T.ok(warm:covers(spine), "covers 覆盖全部 href")
+        T.eq(warm:get("OEBPS/c1.xhtml"), CH1, "c1 内容一致")
+        T.eq(warm:get("OEBPS/c2.xhtml"), CH2, "c2 内容一致")
+
+        -- 缺 href 的 spine 不应被 covers(暖路径会回退真实读取)
+        T.ok(not warm:covers({{href = "OEBPS/missing.xhtml"}}), "缺 href 不 covers")
+
+        -- 指纹变更(换书/升算法)→ 旧缓存整体作废,回到冷模式
+        local other = SpineCache.open(dir, "99999@8")
+        T.ok(other and not other:warm(), "指纹不符→冷模式重捕")
+    end)
+end)
+
+T.case("SpineCache: 缓存缺失 get 返回 nil", function()
+    with_memfs(function()
+        local dir = "tests/.tmp_spine/spine-miss_7"
+        local sig = "12345@7"
+        local cold = SpineCache.open(dir, sig)
+        cold:put("OEBPS/c1.xhtml", CH1)
+        cold:close()
+        local warm = SpineCache.open(dir, sig)
+        T.eq(warm:get("OEBPS/c2.xhtml"), nil, "未在缓存的 href get 返回 nil")
+        T.eq(warm:get("nonexistent"), nil, "完全未知 href get 返回 nil")
+        -- 暖模式但请求未在 entries 的 href:covers 必为 false(迫使回退真实读取)
+        T.ok(not warm:covers({{href = "OEBPS/c2.xhtml"}}), "含未缓存 href 的 spine 不 covers")
+    end)
+end)
+
+T.case("SpineCache: 写盘失败不崩溃,get 优雅返回 nil", function()
+    -- 原子写失败时(模拟磁盘满抛错),put/close 必须不抛出,且 get 应优雅
+    -- 回退 nil(走真实读取补写),绝不污染后续匹配结果。
+    with_memfs(function()
+        local dir = "tests/.tmp_spine/spine-fail_7"
+        local sig = "111@7"
+        local sc = SpineCache.open(dir, sig)
+        T.ok(sc and not sc:warm(), "冷模式开启(写盘失败路径)")
+        local saved_atomic = U.atomic_write
+        U.atomic_write = function() error("disk full") end
+        local ok_put, err_put = pcall(function() sc:put("OEBPS/c1.xhtml", CH1) end)
+        U.atomic_write = saved_atomic
+        T.ok(ok_put, "put 在写盘失败时仍不抛错: " .. tostring(err_put))
+        T.eq(sc:get("OEBPS/c1.xhtml"), nil, "get 写盘失败内容返回 nil(回退真实读取)")
+        local ok_close = pcall(sc.close, sc)
+        T.ok(ok_close, "close 在写盘失败时仍不抛错")
+    end)
+end)
+
+T.case("SpineCache: 中断残留缓存被清并重捕", function()
+    with_memfs(function(fs)
+        local dir = "tests/.tmp_spine/spine-interrupt_7"
+        local sig = "12345@7"
+        -- 预置「中断残留」:目录存在但无 manifest,仅一个半截文件。
+        fs[dir] = true
+        fs[dir .. "/e1"] = "<html partial"
+        -- open:无 manifest → cold,且清空残留目录。
+        local sc = SpineCache.open(dir, sig)
+        T.ok(sc and not sc:warm(), "无 manifest 的残留目录→冷模式重捕")
+        T.ok(fs[dir .. "/e1"] == nil, "残留半截文件被清理")
+        -- 重捕应能正常写入并在下一轮暖命中。
+        sc:put("OEBPS/c1.xhtml", CH1)
+        sc:close()
+        local warm = SpineCache.open(dir, sig)
+        T.ok(warm and warm:warm(), "重捕后暖命中")
+        T.eq(warm:get("OEBPS/c1.xhtml"), CH1, "重捕内容一致")
+    end)
+end)


### PR DESCRIPTION
## 原作者要求（Mr54233）

拆分后的第三项：**正文 spine 缓存**。

具体要求：
- 分批同步时，每批都要把整本书的 spine 文件从 EPUB 解压进内存再 normalize，慢书 + 低性能设备（FAT32 SD、256MB RAM）上反复解压很费时；要求把**每个 spine 文件的原始 HTML 落盘缓存**，后续批次直读缓存、不再解压原 EPUB。
- 明确范围：**只做单书态缓存（B）**，不引入多书绑定逻辑。

## 本 PR 如何达成作者的要求

- **spine 原始 HTML 落盘缓存**：新增 `spine_cache.lua`，把每个 spine 文件的 `read_text` 原始输出按「源书指纹」缓存到与 `map.json` 同目录的 `spine-<指纹>` 文件。
- **暖模式直读缓存**：`sync.lua` 在 map 阶段用 `cached_read_text` / `cached_read_spine` 包装——暖模式（缓存命中）直接读盘上缓存文本，**不再解压 EPUB、不再重复 normalize**；冷模式真实读取并捕获。
- **缓存失效安全**：指纹与 `map.json` 同源（源书大小@算法版本），换书或升算法自动整体作废；中断残留由 `SpineCache` 启动时清理；缓存的是原始 HTML，ChapterMap 仍照常 normalize（幂等），匹配/注入结果与不缓存时**逐字节一致**。
- **开关明确**：`sync_task.lua` 仅置 `spine_cache = true` 开启；单书态下 `map_cache_path` 本就是字符串，无多书 F2 回归。

## 详细说明

### 动机
分批同步时每批都重新解压整本 EPUB 的 spine 再 normalize，慢书/低性能设备上反复解压开销大、易触发看门狗超时。

### 改动
- `spine_cache.lua`：新模块（通用、无多书耦合），冷捕→暖服、指纹作废、中断残留清理。
- `sync.lua`：+B 块 + `cached_read_text`/`cached_read_spine` 包装（`map_cache_path` 直接当字符串用，不引入多书助手）。
- `sync_task.lua`：仅置 `spine_cache = true` 开关。
- `tests/test_spine_cache.lua`：新增——冷→暖用例 + 写盘失败 / 缓存缺失 / 中断恢复 三扩展。
- `tests/run.lua`：注册 `test_spine_cache`。

### 影响范围
同步期 spine 读取通道；注入字节结果与不缓存时一致；未引入多书（D）逻辑。

### 校验
- LuaJIT 语法：OK（3 文件）
- 全套件：**127 passed / 0 failed**（新增 4 用例）
- 多书（D）残留扫描：**0**；CRLF：**0**

