### PR TITLE
SQLite 数据库完整性校验与 WAL 折叠

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 DEV_NOTES.md
 .build/
 __pycache__/
+
+# 测试临时目录(测试运行期创建,由 rm_tmp 清理;失败残留亦忽略)
+tests/_iso_tmp_*/

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -49,7 +49,24 @@ local function set_user_version(db, v)
     pcall(function() db:exec("PRAGMA user_version=" .. tostring(v)) end)
 end
 
--- 创建表 + 迁移追踪:user_version 低于当前则在此升级(目前 v1 无结构性迁移,仅补版本号)。
+-- 迁移分发点:目前仅 SCHEMA_VERSION=1,无结构性迁移。未来升级时按 user_version
+-- 顺序在此执行,例如:for v = from+1, SCHEMA_VERSION do MIGRATIONS[v](db) end
+-- 注意:本插件无线上账号/云同步,想法可由本地注入源(离线缓存)重建,故 open 内
+-- 不做"数据迁移式重建";损坏库交由 isolate_corrupt 隔离,由用户/同步重新注入。
+local MIGRATIONS = {}  -- 预留:MIGRATIONS[2] = function(db) ... end
+
+local function migrate(db, from_version)
+    for v = (from_version or 0) + 1, SCHEMA_VERSION do
+        if MIGRATIONS[v] then
+            local ok, err = pcall(MIGRATIONS[v], db)
+            if not ok then
+                logger.warn("[撷思][ThoughtDB] 迁移 v" .. tostring(v) .. " 失败", tostring(err))
+            end
+        end
+    end
+end
+
+-- 创建表 + 迁移追踪:user_version 低于当前则在此升级(目前 v1 仅补版本号,无结构性迁移)。
 local function ensure_schema(db)
     local ok = pcall(function()
         db:exec([[CREATE TABLE IF NOT EXISTS review_items (
@@ -67,6 +84,7 @@ local function ensure_schema(db)
     if not ok then return false end
     local ver = get_user_version(db)
     if ver < SCHEMA_VERSION then
+        migrate(db, ver)
         set_user_version(db, SCHEMA_VERSION)
     end
     return true
@@ -89,28 +107,66 @@ end
 
 -- 完整性核验:PRAGMA integrity_check 返回 "ok" 即健康,否则收集损坏描述。
 -- FAT32/SD 卡易损,KPW3 上收益最大。
+-- 返回约定(与 open 的契约):
+--   true                  → 健康(detail 为 nil)
+--   false, detail         → 确认损坏(detail 为损坏描述,非异常)
+--   抛错                  → 核验过程本身失败(prepare/step 异常、I/O、busy/locked、
+--                          格式异常等)。open 必须按"过程失败"处理,绝不删库。
+--   (db 为 nil 时返回 false,"no db",属调用方契约错误,不抛错。)
 function ThoughtDB.integrity_check(db)
     if not db then return false, "no db" end
-    local ok, stmt = pcall(function() return db:prepare("PRAGMA integrity_check") end)
-    if not ok or not stmt then return false, "prepare failed" end
-    local bad, step_ok, row = {}, pcall(function() return stmt:step() end)
-    while step_ok and row do
+    local stmt = db:prepare("PRAGMA integrity_check")
+    if not stmt then error("integrity_check prepare 失败") end
+    local bad = {}
+    local row = stmt:step()
+    while row do
         if tostring(row[1] or "") ~= "ok" then bad[#bad + 1] = tostring(row[1]) end
-        step_ok, row = pcall(function() return stmt:step() end)
+        row = stmt:step()
     end
-    pcall(function() stmt:close() end)
-    if not step_ok then return false, "step failed" end
+    stmt:close()
     if #bad == 0 then return true end
     return false, table.concat(bad, "; ")
 end
 
--- WAL 检查点:把 WAL 折叠进主库并截断,减小断电损坏面、回收 -wal/-shm 文件。
-function ThoughtDB.checkpoint(db)
-    if not db then return false end
-    return pcall(function() db:exec("PRAGMA wal_checkpoint(TRUNCATE)") end)
+-- 损坏隔离:把 .db/-wal/-shm 重命名为 .corrupt-<ts>,保留证据供诊断/人工恢复。
+-- 用 os.rename(而非 os.remove)以保证想法数据可恢复,绝不静默丢弃。
+function ThoughtDB.isolate_corrupt(book_dir)
+    local base = ThoughtDB.db_path(book_dir)
+    local ts = os.time()
+    local target = base .. ".corrupt-" .. tostring(ts)
+    if not os.rename(base, target) then return nil end
+    -- 一并隔离 WAL/SHM(若存在);失败不阻断主隔离。
+    os.rename(base .. "-wal", target .. "-wal")
+    os.rename(base .. "-shm", target .. "-shm")
+    return target
 end
 
-function ThoughtDB.open(book_dir, _attempt)
+-- WAL 检查点:把 WAL 折叠进主库并截断,减小断电损坏面、回收 -wal/-shm 文件。
+-- 读取 PRAGMA 真实返回 (total_frames, ckpt_frames, status);status=0 才算成功,
+-- busy/失败不再被当作"成功"。
+function ThoughtDB.checkpoint(db)
+    if not db then return false, "no db" end
+    local stmt = db:prepare("PRAGMA wal_checkpoint(TRUNCATE)")
+    if not stmt then
+        logger.warn("[撷思][ThoughtDB] checkpoint prepare 失败")
+        return false, "prepare failed"
+    end
+    local ok, row = pcall(function() return stmt:step() end)
+    pcall(function() stmt:close() end)
+    if not ok or not row then
+        logger.warn("[撷思][ThoughtDB] checkpoint step 失败")
+        return false, "step failed"
+    end
+    -- 列序:total_frames, ckpt_frames, status
+    local status = tonumber(row[3]) or -1
+    if status ~= 0 then
+        logger.warn("[撷思][ThoughtDB] checkpoint 未完成, status=", status)
+        return false, "checkpoint busy/status=" .. tostring(status)
+    end
+    return true
+end
+
+function ThoughtDB.open(book_dir)
     if type(book_dir) ~= "string" or book_dir == "" then return nil end
     local SQ3 = get_sq3()
     if not SQ3 then return nil end
@@ -118,16 +174,22 @@ function ThoughtDB.open(book_dir, _attempt)
     local path = ThoughtDB.db_path(book_dir)
     local db = do_open(path)
     if not db then return nil end
-    -- 打开即核验完整性;损坏则丢弃本地缓存(想法可由注入源重建),重建干净库,仅重试一次防递归。
-    local ic_ok, healthy, msg = pcall(ThoughtDB.integrity_check, db)
-    if not ic_ok or healthy ~= true then
-        logger.warn("[撷思][ThoughtDB] integrity_check 异常,重建", path, tostring(msg or healthy))
+    -- 打开即核验完整性。必须区分两类失败(作者评审意见 #4):
+    -- (1) 过程失败(prepare/step 抛错、I/O、busy/locked):不是损坏,保留原库,绝不删。
+    -- (2) 确认损坏:隔离(重命名)而非删除,绝不静默重建空库。
+    local ic_ok, healthy, detail = pcall(ThoughtDB.integrity_check, db)
+    if not ic_ok then
+        logger.warn("[撷思][ThoughtDB] integrity_check 过程失败,保留原库", path, tostring(healthy))
         pcall(ThoughtDB.close, db)
-        if not _attempt then
-            ThoughtDB.remove_db(book_dir)
-            return ThoughtDB.open(book_dir, true)
+        return nil, "integrity_check 过程失败: " .. tostring(healthy)
+    elseif healthy ~= true then
+        logger.warn("[撷思][ThoughtDB] integrity_check 检出损坏,隔离而非删除", path, tostring(detail))
+        pcall(ThoughtDB.close, db)
+        local iso = ThoughtDB.isolate_corrupt(book_dir)
+        if iso then
+            return nil, "已隔离损坏库至 " .. iso .. ";想法可由本地注入源(离线缓存)重建"
         end
-        return nil
+        return nil, "损坏库隔离失败(无法重命名);请手动检查 " .. path
     end
     return db
 end

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -125,20 +125,47 @@ function ThoughtDB.integrity_check(db)
     return false, table.concat(bad, "; ")
 end
 
--- 生成真正唯一的损坏备份目标名:时间戳 + 递增序号,并在重命名前再次检查目标
--- 是否已存在;目标已存在则换名,绝不覆盖(作者意见 #2:仅 os.time() 在 Kindle
--- 同秒重复隔离时可能覆盖旧备份)。
-local function unique_corrupt_target(base)
+-- 无覆盖目标预留:先探测候选目标是否空闲(io.open 不存在),再用 os.rename 占用;
+-- 任一步失败(目标被占/权限/IO)均持续换名重试,绝不返回未经确认的候选
+-- (作者第3轮意见 #2:消除"探测后 rename"的竞态隐患,且序号到顶后再次确认目标为空)。
+-- 仅在 rename 真正成功时返回占用名;极端持续失败时返回 nil。
+local function reserve_corrupt_main(base)
     local ts = os.time()
     local salt = 0
-    while true do
+    local attempts = 0
+    while attempts < 100000 do
+        attempts = attempts + 1
         local cand = base .. ".corrupt-" .. tostring(ts) .. "-" .. tostring(salt)
         local probe = io.open(cand, "r")
-        if not probe then return cand end  -- 目标空闲,可用
-        probe:close()
+        if not probe then
+            -- 目标空闲才占用;rename 失败(极小概率竞态/权限)则换名重试。
+            if os.rename(base, cand) then return cand end
+        else
+            probe:close()
+        end
         salt = salt + 1
-        if salt > 9999 then return cand end  -- 安全阀,极端场景也返回最后一个候选
+        if salt > 9999 then ts = os.time(); salt = 0 end  -- 安全阀:换时间戳继续,再次确认
     end
+    return nil
+end
+
+-- 区分"文件不存在"与"因权限/I-O 无法检查"(作者第3轮意见 #3)。
+-- lfs(libs/libkoreader-lfs)在 KOReader 运行时可用,其 attributes 的错误码可区分
+-- 二者;测试环境无 lfs 时退化为 io.open 探测(此时无法区分,保守按"可检查"处理)。
+-- 返回 (exists, state):state 为 "uncheckable" 表示无法确认(权限/IO),调用方应保守处理。
+local function path_exists_distinct(path)
+    local lfsm = package.loaded["libs/libkoreader-lfs"]
+    if lfsm and lfsm.attributes then
+        local attr, err = lfsm.attributes(path)
+        if attr then return true, nil end
+        if err and tostring(err):lower():find("no such file") then
+            return false, nil
+        end
+        return false, "uncheckable"
+    end
+    local f = io.open(path, "r")
+    if f then f:close(); return true, nil end
+    return false, nil
 end
 
 -- 写入并校验隔离标记:.isolated 存在即视为已隔离,即使主库仍残留也阻断自动重建
@@ -164,35 +191,30 @@ end
 -- 返回约定:成功返回 target 路径;否则返回 nil,err。
 function ThoughtDB.isolate_corrupt(book_dir)
     local base = ThoughtDB.db_path(book_dir)
-    -- 枚举实际存在的主库/WAL/SHM。
-    local sidecars = { "-wal", "-shm" }
-    local present = {}
-    do
-        local p = io.open(base, "r")
-        if p then p:close(); present[base] = true end
-    end
-    for _, ext in ipairs(sidecars) do
-        local src = base .. ext
-        local p = io.open(src, "r")
-        if p then p:close(); present[src] = true end
-    end
-    if not present[base] then
+    -- 主库必须存在才隔离;无法确认主库状态时保守报错,绝不静默跳过(避免损坏证据丢失)。
+    local main_exists, main_state = path_exists_distinct(base)
+    if not main_exists then
+        if main_state == "uncheckable" then
+            return nil, "主库状态无法确认(权限/IO),隔离中止以保护原库"
+        end
         return nil, "主库不存在,无需隔离"
     end
     -- 1) 标记先行:标记写入失败 → 中止,绝不移动主库。
     if not write_isolated_marker(base) then
         return nil, "隔离标记写入失败,中止隔离以保护原库"
     end
-    -- 2) 主库移动(唯一目标名,防同秒覆盖)。
-    local target = unique_corrupt_target(base)
-    if not os.rename(base, target) then
+    -- 2) 主库移动(以 rename 自身预留唯一目标,消除探测后 rename 竞态)。
+    local target = reserve_corrupt_main(base)
+    if not target then
         -- 主库移动失败:标记已就位(阻断),不回滚标记,直接报错。
         return nil, "主库重命名失败(隔离标记已就位,阻断自动重建)"
     end
-    -- 3) sidecar 逐个移动;源存在却失败 → 归档不完整。
-    for _, ext in ipairs(sidecars) do
+    -- 3) sidecar 逐个移动;源存在(或无法确认)却失败 → 归档不完整,返回错误。
+    --    绝不把"无法检查"的 sidecar 误判为不存在而留下未归档文件(作者第3轮意见 #3)。
+    for _, ext in ipairs({ "-wal", "-shm" }) do
         local src = base .. ext
-        if present[src] then
+        local exists, state = path_exists_distinct(src)
+        if exists or state == "uncheckable" then
             if not os.rename(src, target .. ext) then
                 -- sidecar 隔离失败:保留标记(阻断自动重建);主库已留在 .corrupt-*
                 -- 作为损坏证据,不回滚(避免把损坏文件移回原处掩盖证据)。

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -31,7 +31,8 @@ end
 
 function ThoughtDB.remove_db(book_dir)
     local path = ThoughtDB.db_path(book_dir)
-    for _, p in ipairs({ path, path .. "-wal", path .. "-shm" }) do
+    -- 同时清理隔离标记:用户主动清缓存后允许下次 open 正常重建(作者意见 #2)。
+    for _, p in ipairs({ path, path .. "-wal", path .. "-shm", path .. ".isolated" }) do
         os.remove(p)
     end
 end
@@ -90,18 +91,14 @@ local function ensure_schema(db)
     return true
 end
 
--- 打开单个库(不含完整性核验与重建),供 open 复用。
+-- 仅打开连接(不做任何 schema 写入),供 open 复用。
+-- 关键:不在打开时执行 CREATE TABLE / user_version 写入,保证随后
+-- 的 integrity_check 是“无写入的只读核验”(作者意见 #5:发现损坏前绝不修改原库)。
 local function do_open(path)
     local SQ3 = get_sq3()
     if not SQ3 then return nil end
     local ok, db = pcall(SQ3.open, path)
     if not ok or not db then return nil end
-    pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
-    pcall(function() db:exec("PRAGMA synchronous=NORMAL") end)
-    if not ensure_schema(db) then
-        pcall(function() db:close() end)
-        return nil
-    end
     return db
 end
 
@@ -130,20 +127,38 @@ end
 
 -- 损坏隔离:把 .db/-wal/-shm 重命名为 .corrupt-<ts>,保留证据供诊断/人工恢复。
 -- 用 os.rename(而非 os.remove)以保证想法数据可恢复,绝不静默丢弃。
+-- 返回约定:成功返回 target 路径;主库重命名失败 / sidecar(源存在却)重命名失败
+-- 均返回 nil,err(作者意见 #3:sidecar 隔离失败不得被吞掉当成成功)。
 function ThoughtDB.isolate_corrupt(book_dir)
     local base = ThoughtDB.db_path(book_dir)
     local ts = os.time()
     local target = base .. ".corrupt-" .. tostring(ts)
-    if not os.rename(base, target) then return nil end
-    -- 一并隔离 WAL/SHM(若存在);失败不阻断主隔离。
-    os.rename(base .. "-wal", target .. "-wal")
-    os.rename(base .. "-shm", target .. "-shm")
+    -- 主库必须先重命名成功,否则无隔离可言。
+    if not os.rename(base, target) then return nil, "主库重命名失败" end
+    -- 一并隔离 WAL/SHM:仅当源文件确实存在时才重命名;源不存在(无 WAL)属正常,
+    -- 不算失败。源存在却重命名失败 → 归档不完整,返回错误(作者意见 #3)。
+    for _, ext in ipairs({ "-wal", "-shm" }) do
+        local src = base .. ext
+        local probe = io.open(src, "r")
+        if probe then
+            probe:close()
+            if not os.rename(src, target .. ext) then
+                return nil, "sidecar 隔离失败: " .. src
+            end
+        end
+    end
+    -- 写入隔离标记:阻止 open() 在下次自动重建空库(作者意见 #2)。
+    -- 旧想法不会因自动建空库而静默不可见;须显式恢复/重同步后才允许重建。
+    local mk = io.open(base .. ".isolated", "w")
+    if mk then mk:close() end
     return target
 end
 
 -- WAL 检查点:把 WAL 折叠进主库并截断,减小断电损坏面、回收 -wal/-shm 文件。
--- 读取 PRAGMA 真实返回 (total_frames, ckpt_frames, status);status=0 才算成功,
--- busy/失败不再被当作"成功"。
+-- wal_checkpoint 返回三列 (busy, log_frames, checkpointed_frames):
+--   busy=1 表示因其他连接忙而未完成;log!=checkpointed 表示未全部折叠。
+-- 旧实现误用 row[3](checkpointed_frames)当状态,会把成功折叠非空 WAL 误判失败、
+-- 把 busy 误判成功(作者意见 #4)。此处以 row[1](busy) 为准。
 function ThoughtDB.checkpoint(db)
     if not db then return false, "no db" end
     local stmt = db:prepare("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -157,13 +172,33 @@ function ThoughtDB.checkpoint(db)
         logger.warn("[撷思][ThoughtDB] checkpoint step 失败")
         return false, "step failed"
     end
-    -- 列序:total_frames, ckpt_frames, status
-    local status = tonumber(row[3]) or -1
-    if status ~= 0 then
-        logger.warn("[撷思][ThoughtDB] checkpoint 未完成, status=", status)
-        return false, "checkpoint busy/status=" .. tostring(status)
+    -- 列序:busy, log_frames, checkpointed_frames
+    local busy = tonumber(row[1]) or 1
+    if busy ~= 0 then
+        logger.warn("[撷思][ThoughtDB] checkpoint busy=", busy)
+        return false, "checkpoint busy"
+    end
+    local log = tonumber(row[2]) or 0
+    local ckpt = tonumber(row[3]) or 0
+    if log ~= ckpt then
+        logger.warn("[撷思][ThoughtDB] checkpoint 不完整 log=", log, " ckpt=", ckpt)
+        return false, "checkpoint 不完整"
     end
     return true
+end
+
+-- 隔离态判定:主库已被重命名为 .corrupt-*,且写入了 .isolated 标记。
+-- 此时禁止 open() 自动重建空库(作者意见 #2):否则旧想法会静默变成不可见,
+-- 须显式恢复或重新同步后才允许重建。
+local function is_isolated(book_dir)
+    local base = ThoughtDB.db_path(book_dir)
+    -- 主库仍存在 → 未隔离(健康或首次打开)。
+    local probe = io.open(base, "r")
+    if probe then probe:close(); return false end
+    -- 主库缺失但存在隔离标记 → 已隔离。
+    local mk = io.open(base .. ".isolated", "r")
+    if mk then mk:close(); return true end
+    return false
 end
 
 function ThoughtDB.open(book_dir)
@@ -171,26 +206,42 @@ function ThoughtDB.open(book_dir)
     local SQ3 = get_sq3()
     if not SQ3 then return nil end
     U.mkdir(book_dir)
+    -- 隔离态:主库已重命名为 .corrupt-*,禁止自动重建空库(作者意见 #2)。
+    if is_isolated(book_dir) then
+        return nil, "数据库已被隔离(损坏),禁止自动重建;请恢复或重新同步"
+    end
     local path = ThoughtDB.db_path(book_dir)
     local db = do_open(path)
     if not db then return nil end
-    -- 打开即核验完整性。必须区分两类失败(作者评审意见 #4):
-    -- (1) 过程失败(prepare/step 抛错、I/O、busy/locked):不是损坏,保留原库,绝不删。
-    -- (2) 确认损坏:隔离(重命名)而非删除,绝不静默重建空库。
+    -- 打开即核验完整性:先做一次无写入的只读核验(作者意见 #5),
+    -- 确认健康后再做连接级 PRAGMA + schema 初始化 / user_version 写入,绝不先改原库。
     local ic_ok, healthy, detail = pcall(ThoughtDB.integrity_check, db)
     if not ic_ok then
         logger.warn("[撷思][ThoughtDB] integrity_check 过程失败,保留原库", path, tostring(healthy))
-        pcall(ThoughtDB.close, db)
+        ThoughtDB.close_no_checkpoint(db)  -- 隔离前不 checkpoint(作者意见 #1)
         return nil, "integrity_check 过程失败: " .. tostring(healthy)
     elseif healthy ~= true then
         logger.warn("[撷思][ThoughtDB] integrity_check 检出损坏,隔离而非删除", path, tostring(detail))
-        pcall(ThoughtDB.close, db)
-        local iso = ThoughtDB.isolate_corrupt(book_dir)
+        ThoughtDB.close_no_checkpoint(db)  -- 隔离前不 checkpoint(作者意见 #1)
+        local iso, iso_err = ThoughtDB.isolate_corrupt(book_dir)
         if iso then
             return nil, "已隔离损坏库至 " .. iso .. ";想法可由本地注入源(离线缓存)重建"
         end
-        return nil, "损坏库隔离失败(无法重命名);请手动检查 " .. path
+        return nil, "损坏库隔离失败(" .. tostring(iso_err or "无法重命名") .. ");请手动检查 " .. path
     end
+    -- 健康:此时才设置连接级 PRAGMA + schema 初始化 / user_version 写入。
+    pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
+    pcall(function() db:exec("PRAGMA synchronous=NORMAL") end)
+    if not ensure_schema(db) then
+        ThoughtDB.close_no_checkpoint(db)
+        return nil, "schema 初始化失败"
+    end
+    -- 健康库建立成功:清理可能残留的隔离标记(作者意见 #2)。
+    -- 仅当标记确实存在时才删除,避免对不存在文件做无效 os.remove。
+    pcall(function()
+        local mk = io.open(path .. ".isolated", "r")
+        if mk then mk:close(); os.remove(path .. ".isolated") end
+    end)
     return db
 end
 
@@ -199,6 +250,12 @@ function ThoughtDB.close(db)
         pcall(ThoughtDB.checkpoint, db)
         pcall(function() db:close() end)
     end
+end
+
+-- 仅关闭句柄,不做 WAL checkpoint。用于损坏 / 过程失败路径,避免在隔离前
+-- 修改或截断主库 / WAL,保证 .corrupt-* 是原始损坏证据(作者意见 #1)。
+function ThoughtDB.close_no_checkpoint(db)
+    if db then pcall(function() db:close() end) end
 end
 
 local function insert_rows(db, chapter_uid, groups)

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -147,10 +147,20 @@ end
 local ffi = nil
 pcall(function() ffi = require("ffi") end)
 local ATOMIC_OPEN, ATOMIC_FLAGS, ATOMIC_MODE
-if ffi and ffi.abi and ffi.abi("os") == "Linux" then
-    ATOMIC_OPEN = ffi.C.open          -- open(2)
-    ATOMIC_FLAGS = 0x40 + 0x80 + 0x1  -- O_CREAT | O_EXCL | O_WRONLY
-    ATOMIC_MODE = 0x180              -- 0600
+-- 修正(作者第5轮意见 #1):ffi.abi("os") 返回布尔值而非字符串,导致 Kindle Linux 永远
+-- 走降级路径、TOCTOU 竞态实际仍存在。正确判断应用 ffi.os(字符串:"Linux"/"Windows"/...)。
+-- 仅 Linux + ffi 可用时启用原子路径(作者第5轮意见 #2:必须补 ffi.cdef 声明 open/close,
+-- 否则加载期报 "missing declaration for symbol 'open'";cdef 冲突则退化为 nil → 降级路径)。
+if ffi and ffi.os == "Linux" then
+    local ok_cdef = pcall(ffi.cdef, [[
+        int open(const char *pathname, int flags, int mode);
+        int close(int fd);
+    ]])
+    if ok_cdef then
+        ATOMIC_OPEN = ffi.C.open          -- open(2)
+        ATOMIC_FLAGS = 0x40 + 0x80 + 0x1  -- O_CREAT | O_EXCL | O_WRONLY
+        ATOMIC_MODE = 0x180              -- 0600
+    end
 end
 
 -- 原子独占创建目标(空文件)。成功返回 true(目标名已独占占有,可安全移入主库内容);

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -116,18 +116,60 @@ function ThoughtDB.integrity_check(db)
     if not stmt then error("integrity_check prepare 失败") end
     local bad = {}
     local row = stmt:step()
+    -- 返回格式校验(作者第4轮意见 #3):integrity_check 必须至少返回一行;
+    -- 否则视为核验过程异常(格式异常),按"过程失败"处理(保留原库、绝不触发隔离)。
+    if not row or type(row) ~= "table" then
+        pcall(function() stmt:close() end)
+        error("integrity_check 返回格式异常:缺少结果行")
+    end
     while row do
-        if tostring(row[1] or "") ~= "ok" then bad[#bad + 1] = tostring(row[1]) end
+        if type(row) ~= "table" then
+            pcall(function() stmt:close() end)
+            error("integrity_check 返回格式异常:结果行非表")
+        end
+        local v = row[1]
+        if type(v) ~= "string" then
+            pcall(function() stmt:close() end)
+            error("integrity_check 返回格式异常:首列非字符串")
+        end
+        if v ~= "ok" then bad[#bad + 1] = v end
         row = stmt:step()
     end
-    stmt:close()
+    pcall(function() stmt:close() end)
     if #bad == 0 then return true end
     return false, table.concat(bad, "; ")
 end
 
--- 无覆盖目标预留:先探测候选目标是否空闲(io.open 不存在),再用 os.rename 占用;
--- 任一步失败(目标被占/权限/IO)均持续换名重试,绝不返回未经确认的候选
--- (作者第3轮意见 #2:消除"探测后 rename"的竞态隐患,且序号到顶后再次确认目标为空)。
+-- 原子无覆盖目标预留:优先用 C.open(O_CREAT|O_EXCL) 在 Linux(含 Kindle ARM Linux)
+-- 上原子占用目标名——"探测即占用",彻底消除"先探测再 os.rename"的 TOCTOU 竞态,
+-- 绝不会覆盖已有 .corrupt-* 备份(作者第4轮意见 #1)。仅 Linux + ffi 可用时启用;
+-- 非 Linux / 无 ffi(如 Windows 测试环境)退化为 probe+rename,同样能正确跳过已存在目标。
+local ffi = nil
+pcall(function() ffi = require("ffi") end)
+local ATOMIC_OPEN, ATOMIC_FLAGS, ATOMIC_MODE
+if ffi and ffi.abi and ffi.abi("os") == "Linux" then
+    ATOMIC_OPEN = ffi.C.open          -- open(2)
+    ATOMIC_FLAGS = 0x40 + 0x80 + 0x1  -- O_CREAT | O_EXCL | O_WRONLY
+    ATOMIC_MODE = 0x180              -- 0600
+end
+
+-- 原子独占创建目标(空文件)。成功返回 true(目标名已独占占有,可安全移入主库内容);
+-- 已存在/权限失败返回 false;ffi 不可用时返回 nil(交由调用方退化处理)。
+local function atomic_claim(cand)
+    if not ATOMIC_OPEN then return nil end
+    local fd = ATOMIC_OPEN(cand, ATOMIC_FLAGS, ATOMIC_MODE)
+    local n = tonumber(fd) or -1
+    if n >= 0 then
+        if ffi.C.close then pcall(ffi.C.close, fd) end
+        return true
+    end
+    return false
+end
+
+-- 无覆盖目标预留:先原子占用候选目标(已存在则跳过换名),再 os.rename 主库内容填入。
+-- 原子路径下候选是我们刚独占的空占位,rename 覆盖它不会触碰任何真实备份;
+-- 退化路径下先 probe 存在即跳过。任一步失败均持续换名重试,绝不返回未经确认的候选
+-- (作者第3轮意见 #2 + 第4轮意见 #1:消除竞态隐患,序号到顶后再次确认目标为空)。
 -- 仅在 rename 真正成功时返回占用名;极端持续失败时返回 nil。
 local function reserve_corrupt_main(base)
     local ts = os.time()
@@ -136,12 +178,23 @@ local function reserve_corrupt_main(base)
     while attempts < 100000 do
         attempts = attempts + 1
         local cand = base .. ".corrupt-" .. tostring(ts) .. "-" .. tostring(salt)
-        local probe = io.open(cand, "r")
-        if not probe then
-            -- 目标空闲才占用;rename 失败(极小概率竞态/权限)则换名重试。
-            if os.rename(base, cand) then return cand end
+        local claimed
+        local ac = atomic_claim(cand)
+        if ac == true then
+            claimed = true   -- 已原子独占 cand(空文件),可安全移入主库内容。
+        elseif ac == false then
+            claimed = false  -- cand 已存在(原子创建失败)→ 跳过换名,绝不覆盖。
         else
-            probe:close()
+            -- 无 ffi / 未知平台:退化 probe——不存在才允许 rename 占用。
+            local probe = io.open(cand, "r")
+            if probe then probe:close(); claimed = false
+            else claimed = true end
+        end
+        if claimed then
+            -- cand 已确认空闲:把主库内容移入(原子路径下覆盖我们刚独占的空占位,
+            -- 不会触碰任何真实备份)。rename 失败(极小概率权限)则清理空占位。
+            if os.rename(base, cand) then return cand end
+            os.remove(cand)
         end
         salt = salt + 1
         if salt > 9999 then ts = os.time(); salt = 0 end  -- 安全阀:换时间戳继续,再次确认
@@ -258,43 +311,58 @@ function ThoughtDB.checkpoint(db)
     return true
 end
 
--- 隔离态判定:以 .isolated 标记为准——标记存在即视为已隔离,即使主库仍残留
--- 也阻断 open() 自动重建空库(作者意见 #2 + 第二轮复审:标记先行阶段主库仍在,
--- 也必须识别标记,否则部分隔离态会被当成"无主库"而静默建空库)。
-local function is_isolated(book_dir)
-    local base = ThoughtDB.db_path(book_dir)
-    local mk = io.open(base .. ".isolated", "r")
-    if mk then mk:close(); return true end
-    return false
-end
+-- 隔离态判定改由 open() 内直接调用 path_exists_distinct 完成(区分"确不存在"与
+-- "无法确认",作者第4轮意见 #2),不再保留单独的 is_isolated 函数。
 
 function ThoughtDB.open(book_dir)
     if type(book_dir) ~= "string" or book_dir == "" then return nil end
     local SQ3 = get_sq3()
     if not SQ3 then return nil end
     U.mkdir(book_dir)
-    -- 隔离态:主库已重命名为 .corrupt-*,禁止自动重建空库(作者意见 #2)。
-    if is_isolated(book_dir) then
+    local base = ThoughtDB.db_path(book_dir)
+    -- 隔离标记:区分"确不存在"与"无法确认"(作者第4轮意见 #2)。
+    -- 无法确认(权限/IO)时保守阻断,避免掩盖隔离态 / 损坏证据。
+    local iso_present, iso_state = path_exists_distinct(base .. ".isolated")
+    if iso_present then
         return nil, "数据库已被隔离(损坏),禁止自动重建;请恢复或重新同步"
     end
-    local path = ThoughtDB.db_path(book_dir)
-    local db = do_open(path)
+    if iso_state == "uncheckable" then
+        return nil, "隔离标记状态无法确认(权限/IO),阻断自动重建以保护数据"
+    end
+    -- 主库存在性:区分"明确不存在"与"无法确认"(作者第4轮意见 #2)。
+    -- 无法确认 → 报错阻断,绝不交给 SQLite 自动创建空库。
+    local main_present, main_state = path_exists_distinct(base)
+    if main_state == "uncheckable" then
+        return nil, "主库状态无法确认(权限/IO),阻断自动重建以保护数据"
+    end
+    if not main_present then
+        -- 主库缺失:检查是否有孤立 sidecar(-wal/-shm)。孤儿 sidecar 表明上次写入中途
+        -- 崩溃,主库可能已损坏/丢失——此时绝不允许 SQLite 静默新建空库(作者第4轮意见 #2)。
+        for _, ext in ipairs({ "-wal", "-shm" }) do
+            local ex, st = path_exists_distinct(base .. ext)
+            if ex or st == "uncheckable" then
+                return nil, "主库缺失但存在孤立 sidecar(" .. ext .. "),阻断自动重建"
+            end
+        end
+        -- 主库确缺失且无 sidecar:允许 SQLite 正常新建(首次打开一本书)。
+    end
+    local db = do_open(base)
     if not db then return nil end
     -- 打开即核验完整性:先做一次无写入的只读核验(作者意见 #5),
     -- 确认健康后再做连接级 PRAGMA + schema 初始化 / user_version 写入,绝不先改原库。
     local ic_ok, healthy, detail = pcall(ThoughtDB.integrity_check, db)
     if not ic_ok then
-        logger.warn("[撷思][ThoughtDB] integrity_check 过程失败,保留原库", path, tostring(healthy))
+        logger.warn("[撷思][ThoughtDB] integrity_check 过程失败,保留原库", base, tostring(healthy))
         ThoughtDB.close_no_checkpoint(db)  -- 隔离前不 checkpoint(作者意见 #1)
         return nil, "integrity_check 过程失败: " .. tostring(healthy)
     elseif healthy ~= true then
-        logger.warn("[撷思][ThoughtDB] integrity_check 检出损坏,隔离而非删除", path, tostring(detail))
+        logger.warn("[撷思][ThoughtDB] integrity_check 检出损坏,隔离而非删除", base, tostring(detail))
         ThoughtDB.close_no_checkpoint(db)  -- 隔离前不 checkpoint(作者意见 #1)
         local iso, iso_err = ThoughtDB.isolate_corrupt(book_dir)
         if iso then
             return nil, "已隔离损坏库至 " .. iso .. ";想法可由本地注入源(离线缓存)重建"
         end
-        return nil, "损坏库隔离失败(" .. tostring(iso_err or "无法重命名") .. ");请手动检查 " .. path
+        return nil, "损坏库隔离失败(" .. tostring(iso_err or "无法重命名") .. ");请手动检查 " .. base
     end
     -- 健康:此时才设置连接级 PRAGMA + schema 初始化 / user_version 写入。
     pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
@@ -306,8 +374,8 @@ function ThoughtDB.open(book_dir)
     -- 健康库建立成功:清理可能残留的隔离标记(作者意见 #2)。
     -- 仅当标记确实存在时才删除,避免对不存在文件做无效 os.remove。
     pcall(function()
-        local mk = io.open(path .. ".isolated", "r")
-        if mk then mk:close(); os.remove(path .. ".isolated") end
+        local mk = io.open(base .. ".isolated", "r")
+        if mk then mk:close(); os.remove(base .. ".isolated") end
     end)
     return db
 end

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -12,6 +12,9 @@ local U = require("pickthought.util")
 
 local ThoughtDB = {}
 
+-- schema 版本:随结构性迁移递增;open 时已落后版本号的库在此升级(user_version 追踪)。
+local SCHEMA_VERSION = 1
+
 local function get_sq3()
     local ok, SQ3 = pcall(require, "lua-ljsqlite3/init")
     if ok and SQ3 then return SQ3 end
@@ -33,17 +36,22 @@ function ThoughtDB.remove_db(book_dir)
     end
 end
 
-function ThoughtDB.open(book_dir)
-    if type(book_dir) ~= "string" or book_dir == "" then return nil end
-    local SQ3 = get_sq3()
-    if not SQ3 then return nil end
-    U.mkdir(book_dir)
-    local path = ThoughtDB.db_path(book_dir)
-    local ok, db = pcall(SQ3.open, path)
-    if not ok or not db then return nil end
-    pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
-    pcall(function() db:exec("PRAGMA synchronous=NORMAL") end)
-    local schema_ok = pcall(function()
+-- 读取/写入 schema 版本(用 SQLite 的 user_version PRAGMA 持久化,免额外表)。
+local function get_user_version(db)
+    local ok, stmt = pcall(function() return db:prepare("PRAGMA user_version") end)
+    if not ok or not stmt then return 0 end
+    local _ok, row = pcall(function() return stmt:step() end)
+    pcall(function() stmt:close() end)
+    return (row and tonumber(row[1])) or 0
+end
+
+local function set_user_version(db, v)
+    pcall(function() db:exec("PRAGMA user_version=" .. tostring(v)) end)
+end
+
+-- 创建表 + 迁移追踪:user_version 低于当前则在此升级(目前 v1 无结构性迁移,仅补版本号)。
+local function ensure_schema(db)
+    local ok = pcall(function()
         db:exec([[CREATE TABLE IF NOT EXISTS review_items (
             chapter_uid TEXT    NOT NULL,
             range       TEXT    NOT NULL,
@@ -56,15 +64,79 @@ function ThoughtDB.open(book_dir)
             PRIMARY KEY (chapter_uid, range, item_index)
         ) WITHOUT ROWID]])
     end)
-    if not schema_ok then
+    if not ok then return false end
+    local ver = get_user_version(db)
+    if ver < SCHEMA_VERSION then
+        set_user_version(db, SCHEMA_VERSION)
+    end
+    return true
+end
+
+-- 打开单个库(不含完整性核验与重建),供 open 复用。
+local function do_open(path)
+    local SQ3 = get_sq3()
+    if not SQ3 then return nil end
+    local ok, db = pcall(SQ3.open, path)
+    if not ok or not db then return nil end
+    pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
+    pcall(function() db:exec("PRAGMA synchronous=NORMAL") end)
+    if not ensure_schema(db) then
         pcall(function() db:close() end)
         return nil
     end
     return db
 end
 
+-- 完整性核验:PRAGMA integrity_check 返回 "ok" 即健康,否则收集损坏描述。
+-- FAT32/SD 卡易损,KPW3 上收益最大。
+function ThoughtDB.integrity_check(db)
+    if not db then return false, "no db" end
+    local ok, stmt = pcall(function() return db:prepare("PRAGMA integrity_check") end)
+    if not ok or not stmt then return false, "prepare failed" end
+    local bad, step_ok, row = {}, pcall(function() return stmt:step() end)
+    while step_ok and row do
+        if tostring(row[1] or "") ~= "ok" then bad[#bad + 1] = tostring(row[1]) end
+        step_ok, row = pcall(function() return stmt:step() end)
+    end
+    pcall(function() stmt:close() end)
+    if not step_ok then return false, "step failed" end
+    if #bad == 0 then return true end
+    return false, table.concat(bad, "; ")
+end
+
+-- WAL 检查点:把 WAL 折叠进主库并截断,减小断电损坏面、回收 -wal/-shm 文件。
+function ThoughtDB.checkpoint(db)
+    if not db then return false end
+    return pcall(function() db:exec("PRAGMA wal_checkpoint(TRUNCATE)") end)
+end
+
+function ThoughtDB.open(book_dir, _attempt)
+    if type(book_dir) ~= "string" or book_dir == "" then return nil end
+    local SQ3 = get_sq3()
+    if not SQ3 then return nil end
+    U.mkdir(book_dir)
+    local path = ThoughtDB.db_path(book_dir)
+    local db = do_open(path)
+    if not db then return nil end
+    -- 打开即核验完整性;损坏则丢弃本地缓存(想法可由注入源重建),重建干净库,仅重试一次防递归。
+    local ic_ok, healthy, msg = pcall(ThoughtDB.integrity_check, db)
+    if not ic_ok or healthy ~= true then
+        logger.warn("[撷思][ThoughtDB] integrity_check 异常,重建", path, tostring(msg or healthy))
+        pcall(ThoughtDB.close, db)
+        if not _attempt then
+            ThoughtDB.remove_db(book_dir)
+            return ThoughtDB.open(book_dir, true)
+        end
+        return nil
+    end
+    return db
+end
+
 function ThoughtDB.close(db)
-    if db then pcall(function() db:close() end) end
+    if db then
+        pcall(ThoughtDB.checkpoint, db)
+        pcall(function() db:close() end)
+    end
 end
 
 local function insert_rows(db, chapter_uid, groups)

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -47,7 +47,8 @@ local function get_user_version(db)
 end
 
 local function set_user_version(db, v)
-    pcall(function() db:exec("PRAGMA user_version=" .. tostring(v)) end)
+    -- 返回写入是否成功(作者第8轮意见 #4):失败契约统一,杜绝"吞掉写入失败"。
+    return pcall(function() db:exec("PRAGMA user_version=" .. tostring(v)) end)
 end
 
 -- 迁移分发点:目前仅 SCHEMA_VERSION=1,无结构性迁移。未来升级时按 user_version
@@ -59,10 +60,15 @@ local MIGRATIONS = {}  -- 预留:MIGRATIONS[2] = function(db) ... end
 local function migrate(db, from_version)
     for v = (from_version or 0) + 1, SCHEMA_VERSION do
         if MIGRATIONS[v] then
-            local ok, err = pcall(MIGRATIONS[v], db)
+            local ok, ret = pcall(MIGRATIONS[v], db)
             if not ok then
-                logger.warn("[撷思][ThoughtDB] 迁移 v" .. tostring(v) .. " 失败", tostring(err))
-                return false  -- 迁移失败立即中止,调用方不得推进 user_version(作者第7轮建议)。
+                logger.warn("[撷思][ThoughtDB] 迁移 v" .. tostring(v) .. " 抛错", tostring(ret))
+                return false  -- 迁移抛错立即中止,调用方不得推进 user_version(作者第7轮建议)。
+            end
+            -- 迁移函数显式返回 false 也视为失败(作者第8轮意见 #4):不推进 user_version。
+            if ret == false then
+                logger.warn("[撷思][ThoughtDB] 迁移 v" .. tostring(v) .. " 返回 false,中止")
+                return false
             end
         end
     end
@@ -87,10 +93,10 @@ local function ensure_schema(db)
     if not ok then return false end
     local ver = get_user_version(db)
     if ver < SCHEMA_VERSION then
-        -- 迁移失败不得推进 user_version:否则下次打开跳过必要迁移(作者第7轮建议)。
-        if migrate(db, ver) then
-            set_user_version(db, SCHEMA_VERSION)
-        end
+        -- 迁移失败 / user_version 写入失败 → 均返回 false,绝不返回"可用库"
+        -- (作者第8轮意见 #4:迁移未完成时不推进版本号、也不返回可用数据库)。
+        if not migrate(db, ver) then return false end
+        if not set_user_version(db, SCHEMA_VERSION) then return false end
     end
     return true
 end
@@ -239,14 +245,28 @@ local function reserve_corrupt_main(base)
                 if held_fd and ffi and ffi.C.close then pcall(ffi.C.close, held_fd) end
                 return cand
             end
-            -- rename 失败:先关闭 fd,再清理占位——仅删除本流程创建的空占位
-            -- (0 字节),若已被其他进程替换成有内容文件则不动,避免误删他人数据。
+            -- rename 失败:先关闭 fd,再按路径决定"立即失败"或"仅竞态换名重试"
+            -- (作者第8轮意见 #1):绝不盲目循环 100000 次阻塞 Kindle。
+            --   - 原子路径(ATOMIC_OPEN 已设置):目标已由 O_EXCL 独占,rename 失败直接
+            --     返回,清理本流程创建的空占位后中止。
+            --   - 退化路径(无 ffi):仅当目标被明确占用(竞态)才换名重试;其他错误
+            --     (权限/磁盘/IO)立即失败,不进入换名循环。.isolated 由调用方保留阻断。
             if held_fd and ffi and ffi.C.close then pcall(ffi.C.close, held_fd) end
-            local probe = io.open(cand, "r")
-            if probe then
-                local sz = probe:seek("end") or 0
-                probe:close()
-                if sz == 0 then pcall(os.remove, cand) end
+            if ATOMIC_OPEN then
+                local probe = io.open(cand, "r")
+                if probe then
+                    local sz = probe:seek("end") or 0
+                    probe:close()
+                    if sz == 0 then pcall(os.remove, cand) end  -- 仅清理本流程空占位,不碰他人数据
+                end
+                return nil, "损坏主库重命名失败(原子预留路径):目标已被占用或 I/O 错误"
+            end
+            local rp, rpe = io.open(cand, "r")
+            if rp then
+                rp:close()
+                -- 目标被明确占用(竞态)→ 落到循环换名重试,绝不覆盖已有备份。
+            else
+                return nil, "无法重命名损坏主库至备份目标(权限/IO 错误): " .. tostring(rpe or "")
             end
         end
         salt = salt + 1
@@ -277,9 +297,11 @@ local function path_exists_distinct(path)
     if f then f:close(); return true, nil end
     -- 退化路径也要区分"不存在"与"权限/IO 错误",避免把无法检查误判为不存在(第6轮意见 #4)。
     local e = tostring(err or ""):lower()
-    if e:find("no such file") or e:find("不存在") or e == "" then
+    if e:find("no such file") or e:find("不存在") then
         return false, nil
     end
+    -- 空错误文本(err=="")不能证明目标不存在,按 uncheckable 处理(作者第8轮意见 #2):
+    -- 阻止自动创建新数据库,避免异常 I/O 下误建空库。
     return false, "uncheckable"
 end
 
@@ -554,5 +576,8 @@ function ThoughtDB.delete_range(db, chapter_uid, range_str)
     end)
     return ok
 end
+
+-- 暴露迁移表供测试注入(验证失败契约);生产代码不写入(当前 MIGRATIONS 为空)。
+ThoughtDB.MIGRATIONS = MIGRATIONS
 
 return ThoughtDB

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -163,24 +163,32 @@ if ffi and ffi.os == "Linux" then
     end
 end
 
--- 原子独占创建目标(空文件)。成功返回 true(目标名已独占占有,可安全移入主库内容);
--- 已存在/权限失败返回 false;ffi 不可用时返回 nil(交由调用方退化处理)。
+-- 原子独占创建目标(空文件)。返回约定(作者第6轮意见 #1/#2):
+--   成功      → true, fd   —— 占位文件已创建,fd 保持打开(调用方在 rename 完成后关闭,
+--                            避免"创建即关、到 rename 之间被删/替换"的竞态);
+--   目标已存在 → "exists"   —— 仅 errno==EEXIST 时,调用方换名重试,绝不覆盖已有备份;
+--   其他错误   → nil, err   —— 权限/磁盘/IO 错误立即中止(绝不盲目循环 100000 次阻塞 Kindle)。
+local EEXIST = 17  -- Linux errno: File exists
 local function atomic_claim(cand)
-    if not ATOMIC_OPEN then return nil end
+    if not ATOMIC_OPEN then return nil, "ffi 不可用" end
     local fd = ATOMIC_OPEN(cand, ATOMIC_FLAGS, ATOMIC_MODE)
     local n = tonumber(fd) or -1
-    if n >= 0 then
-        if ffi.C.close then pcall(ffi.C.close, fd) end
-        return true
+    if n >= 0 then return true, fd end
+    local errno = 0
+    if ffi and ffi.errno then
+        local ok, e = pcall(ffi.errno)
+        if ok then errno = tonumber(e) or 0 end
     end
-    return false
+    if errno == EEXIST then return "exists" end
+    return nil, "目标占用失败(errno=" .. tostring(errno) .. ")"
 end
 
 -- 无覆盖目标预留:先原子占用候选目标(已存在则跳过换名),再 os.rename 主库内容填入。
 -- 原子路径下候选是我们刚独占的空占位,rename 覆盖它不会触碰任何真实备份;
 -- 退化路径下先 probe 存在即跳过。任一步失败均持续换名重试,绝不返回未经确认的候选
 -- (作者第3轮意见 #2 + 第4轮意见 #1:消除竞态隐患,序号到顶后再次确认目标为空)。
--- 仅在 rename 真正成功时返回占用名;极端持续失败时返回 nil。
+-- 仅在 rename 真正成功时返回占用名;目标已存在换名重试;非 EEXIST 错误立即中止(第6轮意见 #1)。
+-- 返回 (target) 或 (nil, err)。
 local function reserve_corrupt_main(base)
     local ts = os.time()
     local salt = 0
@@ -188,14 +196,19 @@ local function reserve_corrupt_main(base)
     while attempts < 100000 do
         attempts = attempts + 1
         local cand = base .. ".corrupt-" .. tostring(ts) .. "-" .. tostring(salt)
-        local claimed
-        local ac = atomic_claim(cand)
+        local claimed, held_fd
+        local ac, ac_err = atomic_claim(cand)
         if ac == true then
-            claimed = true   -- 已原子独占 cand(空文件),可安全移入主库内容。
-        elseif ac == false then
-            claimed = false  -- cand 已存在(原子创建失败)→ 跳过换名,绝不覆盖。
+            claimed = true
+            held_fd = ac_err  -- 占位 fd:保持打开,rename 完成后才关闭(第6轮意见 #2)。
+        elseif ac == "exists" then
+            claimed = false  -- cand 已存在(EEXIST)→ 跳过换名,绝不覆盖。
         else
-            -- 无 ffi / 未知平台:退化 probe——不存在才允许 rename 占用。
+            -- 无 ffi / 未知平台:退化 probe——不存在才允许 rename 占用;
+            -- 或原子路径下遇非 EEXIST 错误(权限/磁盘/IO):立即中止,不盲目循环。
+            if ATOMIC_OPEN then
+                return nil, tostring(ac_err or "目标占用失败")
+            end
             local probe = io.open(cand, "r")
             if probe then probe:close(); claimed = false
             else claimed = true end
@@ -203,21 +216,36 @@ local function reserve_corrupt_main(base)
         if claimed then
             -- cand 已确认空闲:把主库内容移入(原子路径下覆盖我们刚独占的空占位,
             -- 不会触碰任何真实备份)。rename 失败(极小概率权限)则清理空占位。
-            if os.rename(base, cand) then return cand end
-            os.remove(cand)
+            if os.rename(base, cand) then
+                if held_fd and ffi and ffi.C.close then pcall(ffi.C.close, held_fd) end
+                return cand
+            end
+            -- rename 失败:先关闭 fd,再清理占位——仅删除本流程创建的空占位
+            -- (0 字节),若已被其他进程替换成有内容文件则不动,避免误删他人数据。
+            if held_fd and ffi and ffi.C.close then pcall(ffi.C.close, held_fd) end
+            local probe = io.open(cand, "r")
+            if probe then
+                local sz = probe:seek("end") or 0
+                probe:close()
+                if sz == 0 then pcall(os.remove, cand) end
+            end
         end
         salt = salt + 1
         if salt > 9999 then ts = os.time(); salt = 0 end  -- 安全阀:换时间戳继续,再次确认
     end
-    return nil
+    return nil, "无法预留损坏备份目标(已重试 100000 次)"
 end
 
--- 区分"文件不存在"与"因权限/I-O 无法检查"(作者第3轮意见 #3)。
--- lfs(libs/libkoreader-lfs)在 KOReader 运行时可用,其 attributes 的错误码可区分
--- 二者;测试环境无 lfs 时退化为 io.open 探测(此时无法区分,保守按"可检查"处理)。
+-- 区分"文件不存在"与"因权限/I-O 无法检查"(作者第3轮意见 #3 + 第6轮意见 #4)。
+-- 显式加载 libs/libkoreader-lfs(而非只查 package.loaded),其 attributes 的错误码可
+-- 区分二者;lfs 不可用时退化 io.open 探测,并据 err 文本同样区分(权限错误 → uncheckable)。
 -- 返回 (exists, state):state 为 "uncheckable" 表示无法确认(权限/IO),调用方应保守处理。
 local function path_exists_distinct(path)
     local lfsm = package.loaded["libs/libkoreader-lfs"]
+    if not lfsm then
+        local ok, loaded = pcall(require, "libs/libkoreader-lfs")
+        if ok then lfsm = loaded end
+    end
     if lfsm and lfsm.attributes then
         local attr, err = lfsm.attributes(path)
         if attr then return true, nil end
@@ -226,9 +254,14 @@ local function path_exists_distinct(path)
         end
         return false, "uncheckable"
     end
-    local f = io.open(path, "r")
+    local f, err = io.open(path, "r")
     if f then f:close(); return true, nil end
-    return false, nil
+    -- 退化路径也要区分"不存在"与"权限/IO 错误",避免把无法检查误判为不存在(第6轮意见 #4)。
+    local e = tostring(err or ""):lower()
+    if e:find("no such file") or e:find("不存在") or e == "" then
+        return false, nil
+    end
+    return false, "uncheckable"
 end
 
 -- 写入并校验隔离标记:.isolated 存在即视为已隔离,即使主库仍残留也阻断自动重建
@@ -267,10 +300,10 @@ function ThoughtDB.isolate_corrupt(book_dir)
         return nil, "隔离标记写入失败,中止隔离以保护原库"
     end
     -- 2) 主库移动(以 rename 自身预留唯一目标,消除探测后 rename 竞态)。
-    local target = reserve_corrupt_main(base)
+    local target, reserve_err = reserve_corrupt_main(base)
     if not target then
-        -- 主库移动失败:标记已就位(阻断),不回滚标记,直接报错。
-        return nil, "主库重命名失败(隔离标记已就位,阻断自动重建)"
+        -- 主库移动失败(含非 EEXIST 错误立即中止):标记已就位(阻断),不回滚标记,直接报错。
+        return nil, "主库重命名失败(" .. tostring(reserve_err or "未知") .. ";隔离标记已就位,阻断自动重建)"
     end
     -- 3) sidecar 逐个移动;源存在(或无法确认)却失败 → 归档不完整,返回错误。
     --    绝不把"无法检查"的 sidecar 误判为不存在而留下未归档文件(作者第3轮意见 #3)。

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -125,32 +125,81 @@ function ThoughtDB.integrity_check(db)
     return false, table.concat(bad, "; ")
 end
 
--- 损坏隔离:把 .db/-wal/-shm 重命名为 .corrupt-<ts>,保留证据供诊断/人工恢复。
+-- 生成真正唯一的损坏备份目标名:时间戳 + 递增序号,并在重命名前再次检查目标
+-- 是否已存在;目标已存在则换名,绝不覆盖(作者意见 #2:仅 os.time() 在 Kindle
+-- 同秒重复隔离时可能覆盖旧备份)。
+local function unique_corrupt_target(base)
+    local ts = os.time()
+    local salt = 0
+    while true do
+        local cand = base .. ".corrupt-" .. tostring(ts) .. "-" .. tostring(salt)
+        local probe = io.open(cand, "r")
+        if not probe then return cand end  -- 目标空闲,可用
+        probe:close()
+        salt = salt + 1
+        if salt > 9999 then return cand end  -- 安全阀,极端场景也返回最后一个候选
+    end
+end
+
+-- 写入并校验隔离标记:.isolated 存在即视为已隔离,即使主库仍残留也阻断自动重建
+-- (防部分隔离态 / 标记先行阶段静默建空库)。返回是否写入成功。
+local function write_isolated_marker(base)
+    local f = io.open(base .. ".isolated", "w")
+    if not f then return false end
+    f:close()
+    local check = io.open(base .. ".isolated", "r")  -- 校验确实落盘
+    if not check then return false end
+    check:close()
+    return true
+end
+
+-- 损坏隔离:把 .db/-wal/-shm 重命名为 .corrupt-<ts>-<salt>,保留证据供诊断/人工恢复。
 -- 用 os.rename(而非 os.remove)以保证想法数据可恢复,绝不静默丢弃。
--- 返回约定:成功返回 target 路径;主库重命名失败 / sidecar(源存在却)重命名失败
--- 均返回 nil,err(作者意见 #3:sidecar 隔离失败不得被吞掉当成成功)。
+-- 失败安全边界(作者第二轮复审 2026-08-15):
+--   1) 标记先行:先写并校验 .isolated,标记失败则不得移动主库,直接报错;
+--   2) 主库/WAL/SHM 逐个移动,每步校验返回值;
+--   3) 任一步失败保留隔离标记(阻断后续自动建库);sidecar 失败尝试回滚主库,
+--      回滚失败仍保持阻断;
+--   4) 核心:无论哪步失败,下次 open() 都不得得到新空库。
+-- 返回约定:成功返回 target 路径;否则返回 nil,err。
 function ThoughtDB.isolate_corrupt(book_dir)
     local base = ThoughtDB.db_path(book_dir)
-    local ts = os.time()
-    local target = base .. ".corrupt-" .. tostring(ts)
-    -- 主库必须先重命名成功,否则无隔离可言。
-    if not os.rename(base, target) then return nil, "主库重命名失败" end
-    -- 一并隔离 WAL/SHM:仅当源文件确实存在时才重命名;源不存在(无 WAL)属正常,
-    -- 不算失败。源存在却重命名失败 → 归档不完整,返回错误(作者意见 #3)。
-    for _, ext in ipairs({ "-wal", "-shm" }) do
+    -- 枚举实际存在的主库/WAL/SHM。
+    local sidecars = { "-wal", "-shm" }
+    local present = {}
+    do
+        local p = io.open(base, "r")
+        if p then p:close(); present[base] = true end
+    end
+    for _, ext in ipairs(sidecars) do
         local src = base .. ext
-        local probe = io.open(src, "r")
-        if probe then
-            probe:close()
+        local p = io.open(src, "r")
+        if p then p:close(); present[src] = true end
+    end
+    if not present[base] then
+        return nil, "主库不存在,无需隔离"
+    end
+    -- 1) 标记先行:标记写入失败 → 中止,绝不移动主库。
+    if not write_isolated_marker(base) then
+        return nil, "隔离标记写入失败,中止隔离以保护原库"
+    end
+    -- 2) 主库移动(唯一目标名,防同秒覆盖)。
+    local target = unique_corrupt_target(base)
+    if not os.rename(base, target) then
+        -- 主库移动失败:标记已就位(阻断),不回滚标记,直接报错。
+        return nil, "主库重命名失败(隔离标记已就位,阻断自动重建)"
+    end
+    -- 3) sidecar 逐个移动;源存在却失败 → 归档不完整。
+    for _, ext in ipairs(sidecars) do
+        local src = base .. ext
+        if present[src] then
             if not os.rename(src, target .. ext) then
+                -- sidecar 隔离失败:保留标记(阻断自动重建);主库已留在 .corrupt-*
+                -- 作为损坏证据,不回滚(避免把损坏文件移回原处掩盖证据)。
                 return nil, "sidecar 隔离失败: " .. src
             end
         end
     end
-    -- 写入隔离标记:阻止 open() 在下次自动重建空库(作者意见 #2)。
-    -- 旧想法不会因自动建空库而静默不可见;须显式恢复/重同步后才允许重建。
-    local mk = io.open(base .. ".isolated", "w")
-    if mk then mk:close() end
     return target
 end
 
@@ -187,15 +236,11 @@ function ThoughtDB.checkpoint(db)
     return true
 end
 
--- 隔离态判定:主库已被重命名为 .corrupt-*,且写入了 .isolated 标记。
--- 此时禁止 open() 自动重建空库(作者意见 #2):否则旧想法会静默变成不可见,
--- 须显式恢复或重新同步后才允许重建。
+-- 隔离态判定:以 .isolated 标记为准——标记存在即视为已隔离,即使主库仍残留
+-- 也阻断 open() 自动重建空库(作者意见 #2 + 第二轮复审:标记先行阶段主库仍在,
+-- 也必须识别标记,否则部分隔离态会被当成"无主库"而静默建空库)。
 local function is_isolated(book_dir)
     local base = ThoughtDB.db_path(book_dir)
-    -- 主库仍存在 → 未隔离(健康或首次打开)。
-    local probe = io.open(base, "r")
-    if probe then probe:close(); return false end
-    -- 主库缺失但存在隔离标记 → 已隔离。
     local mk = io.open(base .. ".isolated", "r")
     if mk then mk:close(); return true end
     return false

--- a/pickthought.koplugin/pickthought/thought_db.lua
+++ b/pickthought.koplugin/pickthought/thought_db.lua
@@ -62,9 +62,11 @@ local function migrate(db, from_version)
             local ok, err = pcall(MIGRATIONS[v], db)
             if not ok then
                 logger.warn("[撷思][ThoughtDB] 迁移 v" .. tostring(v) .. " 失败", tostring(err))
+                return false  -- 迁移失败立即中止,调用方不得推进 user_version(作者第7轮建议)。
             end
         end
     end
+    return true
 end
 
 -- 创建表 + 迁移追踪:user_version 低于当前则在此升级(目前 v1 仅补版本号,无结构性迁移)。
@@ -85,8 +87,10 @@ local function ensure_schema(db)
     if not ok then return false end
     local ver = get_user_version(db)
     if ver < SCHEMA_VERSION then
-        migrate(db, ver)
-        set_user_version(db, SCHEMA_VERSION)
+        -- 迁移失败不得推进 user_version:否则下次打开跳过必要迁移(作者第7轮建议)。
+        if migrate(db, ver) then
+            set_user_version(db, SCHEMA_VERSION)
+        end
     end
     return true
 end
@@ -209,9 +213,24 @@ local function reserve_corrupt_main(base)
             if ATOMIC_OPEN then
                 return nil, tostring(ac_err or "目标占用失败")
             end
-            local probe = io.open(cand, "r")
-            if probe then probe:close(); claimed = false
-            else claimed = true end
+            local probe, probe_err = io.open(cand, "r")
+            if probe then
+                probe:close()
+                claimed = false  -- 目标已存在 → 换名,绝不覆盖。
+            else
+                -- 退化 probe 失败:仅"明确不存在"(ENOENT/No such file)才视为目标空闲、
+                -- 允许继续尝试;权限/磁盘/IO 等其他错误立即返回失败,不进入换名循环
+                -- (与 Linux 原子路径"仅 EEXIST 换名、其他错误立即失败"一致,避免最多
+                -- 100000 次循环长时间阻塞 Kindle)。.isolated 标记由调用方保留阻断建库。
+                local perr = tostring(probe_err or ""):lower()
+                if perr:find("no such file", 1, true)
+                    or perr:find("not exist", 1, true)
+                    or perr:find("enoent", 1, true) then
+                    claimed = true
+                else
+                    return nil, "无法探测损坏备份目标(权限/IO 错误): " .. tostring(probe_err)
+                end
+            end
         end
         if claimed then
             -- cand 已确认空闲:把主库内容移入(原子路径下覆盖我们刚独占的空占位,

--- a/pickthought.koplugin/pickthought/thoughts.lua
+++ b/pickthought.koplugin/pickthought/thoughts.lua
@@ -114,8 +114,8 @@ local function open_db(store, book_id)
         db_cache_touch(book_dir)
         return db
     end
-    db = ThoughtDB.open(book_dir)
-    if not db then return nil end
+    db, open_err = ThoughtDB.open(book_dir)
+    if not db then return nil, open_err end  -- 透传 ThoughtDB.open 的具体错误(作者第8轮意见 #3)
     db_cache[book_dir] = db
     db_cache_touch(book_dir)
     db_cache_evict()
@@ -128,8 +128,8 @@ local function open_db(store, book_id)
 end
 
 function Thoughts.save(store, book_id, chapter_uid, groups)
-    local db = open_db(store, book_id)
-    if not db then return nil, "想法数据库不可用" end
+    local db, dberr = open_db(store, book_id)
+    if not db then return nil, dberr or "想法数据库不可用" end
     local count = 0
     for _, g in ipairs(groups or {}) do
         if type(g) == "table" then
@@ -190,7 +190,7 @@ function Thoughts.merge(store, book_id, chapter_uid, from_range, into_range)
     from_range, into_range = tostring(from_range or ""), tostring(into_range or "")
     if from_range == "" or into_range == "" or from_range == into_range then return false end
     local db = open_db(store, book_id)
-    if not db then return false end
+    if not db then return false end  -- 失败静默:merge 上层仅判真/假,无错误通道(保持原契约)
     local uid = tostring(chapter_uid or "")
     local from_texts = ThoughtDB.get_range(db, uid, from_range)
     if not from_texts or #from_texts == 0 then return false end
@@ -207,8 +207,8 @@ function Thoughts.merge(store, book_id, chapter_uid, from_range, into_range)
 end
 
 function Thoughts.find(store, book_id, chapter_uid, range)
-    local db = open_db(store, book_id)
-    if not db then return nil, "想法数据库不可用" end
+    local db, dberr = open_db(store, book_id)
+    if not db then return nil, dberr or "想法数据库不可用" end
     local texts = ThoughtDB.get_range(db, tostring(chapter_uid or ""), tostring(range or ""))
     if not texts or #texts == 0 then return nil, "没有找到该划线对应的想法" end
     return { range = tostring(range), texts = texts }

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,4 +1,5 @@
 -- 用法:luajit tests/run.lua(在仓库根目录)
+io.stdout:setvbuf("no") -- 非 TTY(管道/重定向)下保证汇总即时刷新
 local T = {passed = 0, failed = 0}
 function T.case(name, fn)
     local ok, err = xpcall(fn, debug.traceback)
@@ -30,7 +31,7 @@ local files = {
     "tests.test_web_fetch", "tests.test_power_inhibit", "tests.test_sync_task",
     "tests.test_sync_gate",
     "tests.test_thought_db", "tests.test_thoughts",
-    "tests.test_annotation_compat",
+    "tests.test_annotation_compat", "tests.test_thought_db_integrity",
     "tests.test_thoughts_lru",
     "tests.test_spine_cache",
     "tests.test_thought_popup",

--- a/tests/stubs.lua
+++ b/tests/stubs.lua
@@ -321,6 +321,14 @@ package.preload["lua-ljsqlite3/init"] = function()
                 if not r then return nil end
                 -- SELECT 顺序:abstract, author, content, likes, review_id
                 return { r.abstract, r.author, r.content, r.likes, r.review_id }
+            elseif sql:find("PRAGMA") then
+                if sql:find("integrity_check") then
+                    if stmt._ic_done then return nil end
+                    stmt._ic_done = true
+                    return { "ok" }
+                end
+                if sql:find("user_version") then return { store.user_version or 0 } end
+                return nil
             end
             return nil
         end
@@ -336,6 +344,8 @@ package.preload["lua-ljsqlite3/init"] = function()
             sql = tostring(sql or "")
             if sql:find("CREATE TABLE") then store.schema = true
             elseif sql:find("DROP TABLE") then store.schema = false; store.rows = {}
+            elseif sql:find("user_version=") then
+                store.user_version = tonumber(sql:match("user_version=(%d+)")) or 0
             end
             -- PRAGMA / BEGIN / COMMIT / ROLLBACK:无操作语义,放行。
             return true

--- a/tests/stubs.lua
+++ b/tests/stubs.lua
@@ -327,6 +327,9 @@ package.preload["lua-ljsqlite3/init"] = function()
                     stmt._ic_done = true
                     return { "ok" }
                 end
+                if sql:find("wal_checkpoint") then
+                    return { 0, 0, 0 }  -- total_frames, ckpt_frames, status(0=成功)
+                end
                 if sql:find("user_version") then return { store.user_version or 0 } end
                 return nil
             end

--- a/tests/stubs.lua
+++ b/tests/stubs.lua
@@ -123,9 +123,30 @@ package.preload["json"] = function()
 end
 
 package.preload["libs/libkoreader-lfs"] = function()
+    -- 忠实模拟真实 lfs.attributes 的存在性语义:
+    --   - 文件存在(1 参)→ 返回属性表; (2 参 "mode")→ 返回 "file"
+    --   - 文件不存在 → 返回 nil, "No such file or directory"(供 path_exists_distinct 区分
+    --     "不存在" 与 "权限/IO 不可检查",即作者第3轮意见 #3)。
+    -- 注:本桩仅识别文件,不识别目录(目录检测依赖 lfs.dir);调用方以
+    --   lfs.attributes(p,"mode")=="directory" 判目录时,桩对目录返回 nil,与旧桩一致,
+    --   故不改变既有目录相关测试行为。
+    local function attributes(path, field)
+        local f = io.open(path, "r")
+        local exists = f ~= nil
+        if f then f:close() end
+        if not exists then
+            return nil, "No such file or directory"
+        end
+        if field then
+            if field == "mode" then return "file" end
+            if field == "modification" then return 0 end
+            return nil
+        end
+        return { mode = "file" }
+    end
     return {
-        attributes = function() return nil end,
-        symlinkattributes = function() return nil end,
+        attributes = attributes,
+        symlinkattributes = attributes,
         dir = function() return function() return nil end end,
         mkdir = function() return true end,
         rmdir = function() return true end,

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -694,3 +694,101 @@ T.case("隔离回退路径(无 FFI):io.open 权限错误 → 立即失败,只试
     T.ok(file_exists(dir .. "/thoughts.db"), "主库未被移动(保护原库)")
     rm_tmp(dir)
 end)
+
+-- =====================================================================
+-- 作者第8轮复审 2026-08-22:迁移失败契约 + 残留边界(4 项意见)
+-- =====================================================================
+
+-- 第8轮意见 #1:原子预留路径(os="Linux")下,主库 rename 到备份目标失败(权限/I-O)
+-- 必须立即失败、不进入换名循环(避免最多 100000 次阻塞 Kindle),并清理本流程空占位。
+T.case("隔离(原子路径):主库 rename 失败立即失败,不循环", function()
+    local AtomicTDB, fake, restore_tdb = with_fake_ffi(nil)  -- 走 Linux 原子分支
+    local dir = tmp_dir()
+    local f = io.open(dir .. "/thoughts.db", "w"); f:write("MAIN"); f:close()
+    -- mock os.rename:对 .corrupt-* 目标一律失败(模拟权限/IO 错误)。
+    local o_rn = os.rename
+    os.rename = function(a, b)
+        if tostring(b):find("%.corrupt%-") then return nil, "mock rename fail" end
+        return o_rn(a, b)
+    end
+    local target, err = AtomicTDB.isolate_corrupt(dir)
+    os.rename = o_rn
+    restore_tdb()
+    T.ok(target == nil, "rename 失败 → 隔离失败")
+    T.ok(tostring(err):find("重命名失败"), "错误含'重命名失败': " .. tostring(err))
+    T.ok(file_exists(dir .. "/thoughts.db"), "主库未被移动(失败即中止,保护原库)")
+    -- 标记先行:rename 失败前 .isolated 已写入并保留(阻断后续自动建空库),这是设计意图。
+    T.ok(file_exists(dir .. "/thoughts.db.isolated"), ".isolated 标记保留(标记先行,阻断自动重建)")
+    rm_tmp(dir)
+end)
+
+-- 第8轮意见 #2:path_exists_distinct 退化路径 io.open 返回空错误文本(err=="")
+-- 不能证明目标不存在,必须按 uncheckable 处理,阻断自动建库。
+T.case("open:退化 io.open 返回空错误文本 → uncheckable 阻断,不误判不存在", function()
+    local dir = tmp_dir()
+    -- 移除 lfs,强制 path_exists_distinct 走 io.open 退化分支。
+    local old_loaded = package.loaded["libs/libkoreader-lfs"]
+    local old_preload = package.preload["libs/libkoreader-lfs"]
+    package.loaded["libs/libkoreader-lfs"] = nil
+    package.preload["libs/libkoreader-lfs"] = nil
+    -- mock io.open:.isolated=不存在;主库路径返回 nil 且错误文本为空(异常 I/O 表现)。
+    local real_io_open = io.open
+    io.open = function(p, mode)
+        if tostring(p):find("%.isolated$") then return nil, "No such file or directory" end
+        if tostring(p):find("thoughts%.db$") then return nil, "" end  -- 空错误文本
+        return real_io_open(p, mode)
+    end
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open(dir)
+    restore()
+    io.open = real_io_open
+    package.loaded["libs/libkoreader-lfs"] = old_loaded
+    package.preload["libs/libkoreader-lfs"] = old_preload
+
+    T.ok(db == nil, "空错误文本 → 无法确认 → open 返回 nil(阻断)")
+    T.ok(tostring(err):find("无法确认"), "错误含'无法确认'(非'不存在'): " .. tostring(err))
+    T.ok(c.rename == 0 and c.remove == 0, "阻断时不隔离不删除")
+    T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建空库(空错误文本不误判为缺失)")
+    rm_tmp(dir)
+end)
+
+-- 第8轮意见 #4:迁移函数显式返回 false(或抛错)→ open 必须返回 nil、绝不推进
+-- user_version、也不返回"可用库"(防止下次打开跳过必要迁移)。
+T.case("迁移返回 false:open 失败,不推进 user_version,不返回可用库", function()
+    SQ3._reset()
+    local ok_inject, inj_err = pcall(function()
+        ThoughtDB.MIGRATIONS[1] = function(_db) return false end
+    end)
+    T.ok(ok_inject, "可注入 MIGRATIONS[1]: " .. tostring(inj_err))
+    local db, err = ThoughtDB.open("/migfail/false")
+    ThoughtDB.MIGRATIONS[1] = nil
+    T.ok(db == nil, "迁移返回 false → open 返回 nil(不返回可用库)")
+    T.ok(tostring(err):find("迁移") or tostring(err):find("schema"),
+        "错误含迁移/schema 原因: " .. tostring(err))
+    rm_rf("/migfail")
+end)
+
+T.case("迁移抛错:open 失败,不推进 user_version", function()
+    SQ3._reset()
+    local ok_inject, inj_err = pcall(function()
+        ThoughtDB.MIGRATIONS[1] = function(_db) error("mock migration error") end
+    end)
+    T.ok(ok_inject, "可注入 MIGRATIONS[1] 抛错: " .. tostring(inj_err))
+    local db, err = ThoughtDB.open("/migfail/err")
+    ThoughtDB.MIGRATIONS[1] = nil
+    T.ok(db == nil, "迁移抛错 → open 返回 nil")
+    T.ok(tostring(err):find("迁移") or tostring(err):find("schema"), "错误含迁移原因")
+    rm_rf("/migfail")
+end)
+
+-- 第8轮意见 #4 反向验证:无迁移且 schema 完整时,user_version 确实写入 SCHEMA_VERSION。
+T.case("无迁移场景:user_version 正常写入 SCHEMA_VERSION", function()
+    SQ3._reset()
+    local db = ThoughtDB.open("/good/mig")
+    T.ok(db ~= nil, "健康库 open 成功")
+    local store = SQ3._stores[ThoughtDB.db_path("/good/mig")]
+    T.ok(store ~= nil, "store 存在")
+    T.eq(store.user_version, 1, "user_version 写为 SCHEMA_VERSION=1(无迁移路径)")
+    if db then ThoughtDB.close(db) end
+    rm_rf("/good")
+end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -13,12 +13,33 @@ local function fresh_db()
 end
 
 -- 单测内 spy os.rename / os.remove,返回计数与还原闭包,用于断言"不删库/确实隔离"。
+-- 同时记录首个 rename 目标(first_target)与全部 (from,to) 对,供真实文件测试核对。
 local function spy_os()
-    local c = { rename = 0, remove = 0 }
+    local c = { rename = 0, remove = 0, first_target = nil, renames = {} }
     local o_rn, o_rm = os.rename, os.remove
-    os.rename = function(...) c.rename = c.rename + 1; return o_rn(...) end
-    os.remove = function(...) c.remove = c.remove + 1; return o_rm(...) end
+    os.rename = function(a, b)
+        c.rename = c.rename + 1
+        c.renames[#c.renames + 1] = { a, b }
+        if c.first_target == nil and b then c.first_target = b end
+        return o_rn(a, b)  -- 仍执行真实重命名,文件真的被移动
+    end
+    os.remove = function(a) c.remove = c.remove + 1; return o_rm(a) end
     return c, function() os.rename, os.remove = o_rn, o_rm end
+end
+
+-- 真实临时目录(用于验证 os.rename 真的移动了文件,而非只调用了 API)。
+local function tmp_dir()
+    local d = "tests/_iso_tmp_" .. tostring(os.time()) .. "_" .. tostring(math.floor(math.random() * 1e7))
+    pcall(function() os.execute('mkdir "' .. d .. '" 2>nul') end)
+    return d
+end
+local function rm_tmp(d)
+    pcall(function() os.execute('rmdir /s /q "' .. d .. '" 2>nul') end)
+end
+-- 真实文件中是否仍存在(存在返回 true)。
+local function file_exists(p)
+    local f = io.open(p, "r"); if f then f:close(); return true end
+    return false
 end
 
 T.case("integrity_check 健康库返回 true", function()
@@ -60,17 +81,115 @@ T.case("open 健康库:正常返回 db,不触发隔离/删除", function()
     if db then ThoughtDB.close(db) end
 end)
 
-T.case("open 遇确认损坏:隔离(.corrupt-*)而非删除,返回 nil", function()
+-- 真实临时文件测试:验证 os.rename 真的把主库 / WAL / SHM 移动到了 .corrupt-*,
+-- 而非只调用了 API(作者意见 #6:旧测试 os.rename 实际失败也能通过)。
+T.case("open 遇确认损坏:真实文件被隔离到 .corrupt-*,绝不删除", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("x"); f:close()
+    end
     local orig = ThoughtDB.integrity_check
     ThoughtDB.integrity_check = function(_d) return false, "mock corrupt" end
     local c, restore = spy_os()
-    local db, err = ThoughtDB.open("/corrupt/book")
+    local db, err = ThoughtDB.open(dir)
     restore()
+    ThoughtDB.integrity_check = orig
     T.ok(db == nil, "确认损坏 → open 返回 nil(不静默重建空库)")
     T.ok(err ~= nil and tostring(err):find("隔离"), "错误描述含'隔离'")
-    T.ok(c.rename >= 1, "损坏库被重命名隔离(.corrupt-*)")
     T.ok(c.remove == 0, "绝不调用 os.remove 删除想法数据")
-    ThoughtDB.integrity_check = orig
+    -- 原主库 / WAL / SHM 应已不在原路径。
+    T.ok(not file_exists(dir .. "/thoughts.db"), "原 thoughts.db 已移走")
+    T.ok(not file_exists(dir .. "/thoughts.db-wal"), "原 -wal 已移走")
+    T.ok(not file_exists(dir .. "/thoughts.db-shm"), "原 -shm 已移走")
+    -- 首个 rename 目标即 .corrupt 主库;其 -wal/-shm 兄弟与 .isolated 标记都应存在。
+    T.ok(c.first_target ~= nil, "记录了主库隔离目标")
+    if c.first_target then
+        T.ok(file_exists(c.first_target), "主库 .corrupt-* 真实存在")
+        T.ok(file_exists(c.first_target .. "-wal"), "sidecar .corrupt-*-wal 真实存在")
+        T.ok(file_exists(c.first_target .. "-shm"), "sidecar .corrupt-*-shm 真实存在")
+        T.ok(file_exists(dir .. "/thoughts.db.isolated"), ".isolated 隔离标记已写入")
+    end
+    rm_tmp(dir)
+end)
+
+-- 作者意见 #2:损坏被隔离后,主库消失且写入 .isolated 标记;
+-- 下次 open() 必须禁止自动重建空库(否则旧想法静默不可见)。
+T.case("open 隔离态:禁止自动重建空库,返回 nil", function()
+    local dir = tmp_dir()
+    -- 仅写隔离标记,不写 thoughts.db(模拟隔离后主库已被移走)。
+    local mk = io.open(dir .. "/thoughts.db.isolated", "w"); mk:close()
+    SQ3._reset()
+    local db, err = ThoughtDB.open(dir)
+    T.ok(db == nil, "隔离态 → open 返回 nil(不自动建库)")
+    T.ok(err ~= nil and tostring(err):find("隔离"), "错误描述含'隔离'")
+    -- 关键:不得自动创建空库(既没有真实文件,也没有内存 store)。
+    T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建真实 thoughts.db")
+    T.ok(SQ3._stores[dir .. "/thoughts.db"] == nil, "未自动创建内存库(无写入)")
+    -- 隔离标记保留,等待显式恢复/重同步。
+    T.ok(file_exists(dir .. "/thoughts.db.isolated"), "隔离标记保留")
+    rm_tmp(dir)
+end)
+
+-- 作者意见 #4:wal_checkpoint 返回 (busy, log, checkpointed),应以 row[1](busy) 为准。
+local function fake_db_with_checkpoint(row)
+    return {
+        prepare = function(_, sql)
+            if sql:find("wal_checkpoint") then
+                return { step = function() return row end, close = function() end }
+            end
+            return { step = function() return nil end, close = function() end }
+        end,
+        close = function() end,
+        exec = function() end,
+    }
+end
+T.case("checkpoint:busy=1 判失败(不再误判成功)", function()
+    local ok, err = ThoughtDB.checkpoint(fake_db_with_checkpoint({ 1, 5, 5 }))
+    T.ok(ok == false, "busy → checkpoint 失败")
+    T.ok(tostring(err):find("busy"), "错误含 busy")
+end)
+T.case("checkpoint:log!=checkpointed 判不完整", function()
+    local ok, err = ThoughtDB.checkpoint(fake_db_with_checkpoint({ 0, 5, 3 }))
+    T.ok(ok == false, "未全部折叠 → checkpoint 失败")
+    T.ok(tostring(err):find("不完整"), "错误含 不完整")
+end)
+T.case("checkpoint:busy=0 且全部折叠 → 成功", function()
+    local ok, err = ThoughtDB.checkpoint(fake_db_with_checkpoint({ 0, 0, 0 }))
+    T.ok(ok == true, "busy=0 且 log==ckpt → checkpoint 成功")
+end)
+
+-- 作者意见 #3:isolate_corrupt 必须逐个检查 sidecar 重命名,源存在却失败时返回错误。
+T.case("isolate_corrupt:主库+sidecar 真实移动并写 .isolated 标记", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("x"); f:close()
+    end
+    local target, err = ThoughtDB.isolate_corrupt(dir)
+    T.ok(target ~= nil, "隔离成功返回目标路径")
+    T.ok(not file_exists(dir .. "/thoughts.db"), "主库已移走")
+    T.ok(not file_exists(dir .. "/thoughts.db-wal"), "-wal 已移走")
+    T.ok(not file_exists(dir .. "/thoughts.db-shm"), "-shm 已移走")
+    T.ok(target and file_exists(target), "主库 .corrupt-* 存在")
+    T.ok(target and file_exists(target .. "-wal"), "sidecar -wal 存在")
+    T.ok(target and file_exists(target .. "-shm"), "sidecar -shm 存在")
+    T.ok(file_exists(dir .. "/thoughts.db.isolated"), ".isolated 标记已写入")
+    rm_tmp(dir)
+end)
+T.case("isolate_corrupt:sidecar 重命名失败返回 nil(不吞错)", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("x"); f:close()
+    end
+    local o_rn = os.rename
+    os.rename = function(a, b)
+        if b:find("-wal$") then return nil, "mock wal fail" end
+        return o_rn(a, b)
+    end
+    local target, err = ThoughtDB.isolate_corrupt(dir)
+    os.rename = o_rn
+    T.ok(target == nil, "sidecar 隔离失败 → 返回 nil")
+    T.ok(err ~= nil and tostring(err):find("sidecar"), "错误含 sidecar")
+    rm_tmp(dir)
 end)
 
 T.case("open 遇核验过程失败(busy/prepare 异常):保留原库,不删", function()

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -6,6 +6,7 @@
 -- wal_checkpoint(返回 {0,0,0}) 与 user_version 读写。
 local ThoughtDB = require("pickthought.thought_db")
 local SQ3 = require("lua-ljsqlite3/init")
+local lfs = require("lfs")
 
 local function fresh_db()
     SQ3._reset()
@@ -28,13 +29,28 @@ local function spy_os()
 end
 
 -- 真实临时目录(用于验证 os.rename 真的移动了文件,而非只调用了 API)。
+-- 跨平台创建(lfs.mkdir,不依赖 Windows mkdir)。
 local function tmp_dir()
     local d = "tests/_iso_tmp_" .. tostring(os.time()) .. "_" .. tostring(math.floor(math.random() * 1e7))
-    pcall(function() os.execute('mkdir "' .. d .. '" 2>nul') end)
+    pcall(lfs.mkdir, d)
     return d
 end
+-- 跨平台递归删除(不依赖 Windows rmdir /s /q;用 lfs 遍历后逐文件/目录删除)。
 local function rm_tmp(d)
-    pcall(function() os.execute('rmdir /s /q "' .. d .. '" 2>nul') end)
+    local function remove_recursive(path)
+        local mode = lfs.attributes(path, "mode")
+        if mode == "directory" then
+            for name in lfs.dir(path) do
+                if name ~= "." and name ~= ".." then
+                    remove_recursive(path .. "/" .. name)
+                end
+            end
+            lfs.rmdir(path)
+        else
+            os.remove(path)
+        end
+    end
+    pcall(remove_recursive, d)
 end
 -- 真实文件中是否仍存在(存在返回 true)。
 local function file_exists(p)
@@ -215,4 +231,98 @@ T.case("open 隔离失败(无法重命名)时显式报错,不静默空库", func
     T.ok(db == nil, "隔离失败 → open 返回 nil")
     T.ok(err ~= nil and tostring(err):find("隔离失败"), "错误描述含'隔离失败'")
     ThoughtDB.integrity_check = orig
+end)
+
+-- 作者第二轮复审 2026-08-15 失败安全边界:sidecar 移动失败后二次 open()
+-- 必须仍被阻断且不自动创建新空库(标记先行 → 标记已留 → 阻断)。
+-- 注意:pcall 包裹测试体,确保任何断言失败时仍 restore 全局 patch,
+-- 不污染后续用例(本文件在 test_thoughts_lru 之前运行)。
+T.case("隔离中途 sidecar 失败:二次 open 仍阻断且不建空库", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("x"); f:close()
+    end
+    local orig = ThoughtDB.integrity_check
+    local o_rn = os.rename
+    local function restore()
+        ThoughtDB.integrity_check = orig
+        os.rename = o_rn
+    end
+    local ok, perr = pcall(function()
+        -- 第一次:确认损坏 → 隔离(标记先行,主库移入 .corrupt-*,但 -wal 移动失败)。
+        ThoughtDB.integrity_check = function(_d) return false, "mock corrupt" end
+        os.rename = function(a, b)
+            if b:find("-wal$") then return nil, "mock wal fail" end
+            return o_rn(a, b)
+        end
+        local db1, err1 = ThoughtDB.open(dir)
+        T.ok(db1 == nil, "首次隔离因 sidecar 失败返回 nil")
+        T.ok(file_exists(dir .. "/thoughts.db.isolated"), "隔离标记已在主库移动前写入(阻断)")
+        T.ok(not file_exists(dir .. "/thoughts.db"), "主库已移入 .corrupt-*(损坏证据保留,不回滚)")
+        -- 第二次 open:标记存在 → 阻断,不建空库(标记在 do_open 前即阻断)。
+        SQ3._reset()
+        local db2, err2 = ThoughtDB.open(dir)
+        T.ok(db2 == nil, "二次 open 被隔离标记阻断,返回 nil")
+        T.ok(err2 ~= nil and tostring(err2):find("隔离"), "二次 open 错误含'隔离'")
+        T.ok(SQ3._stores[dir .. "/thoughts.db"] == nil, "二次 open 未创建内存库(标记在 do_open 前阻断)")
+        T.ok(file_exists(dir .. "/thoughts.db.isolated"), "隔离标记仍保留(保持阻断)")
+    end)
+    restore()
+    rm_tmp(dir)
+    if not ok then error(perr) end
+end)
+
+-- 作者第二轮复审 2026-08-15 失败安全边界:.isolated 标记写入失败时,
+-- 不得移动主库,且后续 open() 不得自动建空库(保护原库)。
+T.case("隔离标记写入失败:不移动主库,二次 open 不建空库", function()
+    local dir = tmp_dir()
+    local f = io.open(dir .. "/thoughts.db", "w"); f:write("x"); f:close()
+    -- 让 .isolated 写入失败:io.open 对 .isolated 返回 nil(模拟不可写)。
+    local orig_ioopen = io.open
+    local orig = ThoughtDB.integrity_check
+    local function restore()
+        io.open = orig_ioopen
+        ThoughtDB.integrity_check = orig
+    end
+    local ok, perr = pcall(function()
+        io.open = function(p, mode)
+            if p:find("%.isolated$") then return nil end
+            return orig_ioopen(p, mode)
+        end
+        ThoughtDB.integrity_check = function(_d) return false, "mock corrupt" end
+        -- 第一次 open:确认损坏 → 隔离(标记写入失败 → 中止,主库不移动)。
+        local db1, err1 = ThoughtDB.open(dir)
+        T.ok(db1 == nil, "标记写入失败 → 隔离中止,open 返回 nil")
+        T.ok(file_exists(dir .. "/thoughts.db"), "主库未被移动(标记失败即中止)")
+        -- 第二次 open:仍无标记(主库仍在),再次走损坏路径 → 标记仍失败 → open 拒绝返回可用库。
+        SQ3._reset()
+        local db2, err2 = ThoughtDB.open(dir)
+        T.ok(db2 == nil, "二次 open 仍拒绝返回可用库(不建空库)")
+        T.ok(not file_exists(dir .. "/thoughts.db.isolated"), "仍无隔离标记")
+    end)
+    restore()
+    rm_tmp(dir)
+    if not ok then error(perr) end
+end)
+
+-- 作者第二轮复审 2026-08-15 唯一备份名:预建同名 .corrupt-* 时,新的隔离
+-- 操作必须换名,不得覆盖旧备份(防 Kindle 同秒重复隔离丢证据)。
+T.case("隔离目标名唯一:预建同名 .corrupt-* 不被覆盖", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("x"); f:close()
+    end
+    -- 预建一个旧备份(同 ts 前缀),里面放"OLD"标记。
+    local base = dir .. "/thoughts.db"
+    local old_ts = os.time()
+    local old_target = base .. ".corrupt-" .. tostring(old_ts) .. "-0"
+    local of = io.open(old_target, "w"); of:write("OLD BACKUP"); of:close()
+    T.ok(file_exists(old_target), "预建旧备份存在")
+    -- 触发隔离:unique_corrupt_target 应避开已存在的 old_target,换新名。
+    local target, err = ThoughtDB.isolate_corrupt(dir)
+    T.ok(target ~= nil, "隔离成功")
+    T.ok(target ~= old_target, "新目标名不同于旧备份(避免覆盖)")
+    T.ok(file_exists(old_target), "旧备份未被覆盖,仍保留")
+    T.ok(file_exists(target), "新隔离目标存在")
+    rm_tmp(dir)
 end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -372,3 +372,130 @@ T.case("隔离:sidecar 无法检查(权限/IO)时保守报错,不静默跳过", 
     T.ok(err ~= nil and tostring(err):find("sidecar"), "错误含 sidecar")
     rm_tmp(dir)
 end)
+
+-- =====================================================================
+-- 作者第4轮复审 2026-08-18:三处数据安全边界补齐(原子预留 / 异常状态判定 / 格式校验)
+-- =====================================================================
+
+-- 第4轮意见 #1:损坏备份目标原子无覆盖预留——预占/并发场景下旧 .corrupt-* 备份内容不被覆盖。
+T.case("隔离:预占场景下旧 .corrupt-* 备份内容不被覆盖", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("MAIN"); f:close()
+    end
+    local base = dir .. "/thoughts.db"
+    local old_ts = os.time()
+    local old_target = base .. ".corrupt-" .. tostring(old_ts) .. "-0"
+    local of = io.open(old_target, "w"); of:write("OLD BACKUP PAYLOAD"); of:close()
+    T.ok(file_exists(old_target), "预建旧备份存在")
+    local target, err = ThoughtDB.isolate_corrupt(dir)
+    T.ok(target ~= nil, "隔离成功")
+    T.ok(target ~= old_target, "新目标名不同于旧备份(避免覆盖)")
+    -- 关键:旧备份内容原样保留,未被新隔离覆盖(无论原子路径还是退化 probe 路径)。
+    local rf = io.open(old_target, "r"); local content = rf and rf:read("*a"); if rf then rf:close() end
+    T.ok(content == "OLD BACKUP PAYLOAD", "旧备份内容未被覆盖")
+    -- 新隔离目标承载真实主库内容。
+    local nf = io.open(target, "r"); local ncontent = nf and nf:read("*a"); if nf then nf:close() end
+    T.ok(ncontent == "MAIN", "新隔离目标承载主库内容")
+    rm_tmp(dir)
+end)
+
+-- 第4轮意见 #2:.isolated 标记读取失败(权限/IO)→ 保守阻断自动重建,避免掩盖隔离态。
+T.case("open:隔离标记无法确认(权限/IO)→ 阻断自动重建", function()
+    local dir = tmp_dir()
+    local old_lfs = package.loaded["libs/libkoreader-lfs"]
+    package.loaded["libs/libkoreader-lfs"] = {
+        attributes = function() return nil, "Permission denied" end,
+    }
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open(dir)
+    restore()
+    package.loaded["libs/libkoreader-lfs"] = old_lfs
+    T.ok(db == nil, "标记无法确认 → open 返回 nil(阻断)")
+    T.ok(err ~= nil and tostring(err):find("无法确认"), "错误含'无法确认'")
+    T.ok(c.rename == 0 and c.remove == 0, "阻断时不隔离不删除")
+    T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建空库")
+    rm_tmp(dir)
+end)
+
+-- 第4轮意见 #2:主库状态无法确认(权限/IO)→ 阻断自动重建,绝不交给 SQLite 建空库。
+T.case("open:主库状态无法确认(权限/IO)→ 阻断自动重建", function()
+    local dir = tmp_dir()
+    -- .isolated 视为不存在,主库视为无法确认;其余随意。
+    local old_lfs = package.loaded["libs/libkoreader-lfs"]
+    package.loaded["libs/libkoreader-lfs"] = {
+        attributes = function(p)
+            if p:find("%.isolated$") then return nil, "No such file or directory" end
+            return nil, "Permission denied"
+        end,
+    }
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open(dir)
+    restore()
+    package.loaded["libs/libkoreader-lfs"] = old_lfs
+    T.ok(db == nil, "主库无法确认 → open 返回 nil(阻断)")
+    T.ok(err ~= nil and tostring(err):find("无法确认"), "错误含'无法确认'")
+    T.ok(c.rename == 0 and c.remove == 0, "阻断时不隔离不删除")
+    T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建空库")
+    rm_tmp(dir)
+end)
+
+-- 第4轮意见 #2:主库缺失但仍有孤立 sidecar(-wal/-shm)→ 阻断自动重建(不静默建空库)。
+T.case("open:主库缺失但有孤立 sidecar → 阻断,不建空库", function()
+    local dir = tmp_dir()
+    -- 仅留 orphan -wal(模拟上次写入中途崩溃),无主库、无 .isolated。
+    local f = io.open(dir .. "/thoughts.db-wal", "w"); f:write("x"); f:close()
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open(dir)
+    restore()
+    T.ok(db == nil, "orphan sidecar → open 返回 nil(阻断)")
+    T.ok(err ~= nil and tostring(err):find("孤立"), "错误含'孤立'")
+    T.ok(c.rename == 0 and c.remove == 0, "阻断时不隔离不删除原(可能残留的)数据")
+    T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建真实 thoughts.db")
+    rm_tmp(dir)
+end)
+
+-- 第4轮意见 #2(放行路径):主库确缺失且无 sidecar → 允许 SQLite 正常新建(首次打开一本书)。
+T.case("open:主库确缺失且无 sidecar → 正常新建", function()
+    SQ3._reset()
+    local clean = "/book/fresh-" .. tostring(os.time()) .. "-" .. tostring(math.floor(math.random() * 1e7))
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open(clean)
+    restore()
+    T.ok(db ~= nil, "首次打开(无主库无 sidecar)→ open 成功")
+    T.ok(err == nil, "无错误")
+    T.ok(c.rename == 0 and c.remove == 0, "无损坏/隔离,不重命名不删除")
+    T.ok(SQ3._stores[clean .. "/thoughts.db"] ~= nil, "内存库已建立(正常新建)")
+    if db then ThoughtDB.close(db) end
+end)
+
+-- 第4轮意见 #3:integrity_check 返回格式异常(无结果行)→ 抛错,按过程失败处理(保留原库)。
+T.case("integrity_check:无结果行(格式异常)→ 抛错(过程失败)", function()
+    local fake = { prepare = function() return { step = function() return nil end, close = function() end } end }
+    local ok, err = pcall(ThoughtDB.integrity_check, fake)
+    T.ok(not ok, "无结果行 → integrity_check 抛错(过程失败,保留原库)")
+    T.ok(err ~= nil and tostring(err):find("格式"), "错误含'格式'")
+end)
+
+-- 第4轮意见 #3:integrity_check 返回首列非字符串(格式异常)→ 抛错,避免误判为确认损坏。
+T.case("integrity_check:首列非字符串(格式异常)→ 抛错", function()
+    local fake = { prepare = function() return { step = function() return { 123 } end, close = function() end } end }
+    local ok, err = pcall(ThoughtDB.integrity_check, fake)
+    T.ok(not ok, "首列非字符串 → 抛错(不误判损坏、不触发隔离)")
+    T.ok(err ~= nil and tostring(err):find("格式"), "错误含'格式'")
+end)
+
+-- 第4轮意见 #3:integrity_check 格式异常经 open 按过程失败处理(保留原库,不隔离不删)。
+T.case("open:integrity_check 格式异常 → 过程失败(保留原库,不隔离不删)", function()
+    local orig = ThoughtDB.integrity_check
+    -- 模拟底层返回格式异常(非标准结果),integrity_check 应抛错 → open 视为过程失败。
+    ThoughtDB.integrity_check = function(_d) error("integrity_check 返回格式异常:缺少结果行") end
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open("/fmt/book")
+    restore()
+    T.ok(db == nil, "格式异常 → open 返回 nil(不静默重建空库)")
+    T.ok(err ~= nil and tostring(err):find("过程失败"), "错误含'过程失败'")
+    T.ok(c.rename == 0, "格式异常不触发隔离/重命名")
+    T.ok(c.remove == 0, "格式异常绝不删除想法数据")
+    ThoughtDB.integrity_check = orig
+end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -499,3 +499,58 @@ T.case("open:integrity_check 格式异常 → 过程失败(保留原库,不隔�
     T.ok(c.remove == 0, "格式异常绝不删除想法数据")
     ThoughtDB.integrity_check = orig
 end)
+
+-- 作者第5轮意见 2026-08-19:原子无覆盖路径在 Kindle Linux 必须真实启用,且测试须覆盖原子分支
+-- (此前 CI 走降级 probe 路径,未验证 O_CREAT|O_EXCL 原子占用)。
+-- 本用例注入 fake ffi(os="Linux" + C.open/C.close 模拟原子占用)强制走原子分支,验证:
+--   ① 目标被占用(已存在 .corrupt-*)时换新名;② 旧 .corrupt-* 内容不被覆盖。
+T.case("原子预留(Linux 分支):目标被占用时换名,旧备份内容不覆盖", function()
+    -- 注入 fake ffi 强制启用原子路径,再重新加载模块(仅本用例作用域,加载后还原全局 ffi)。
+    local real_ffi = package.loaded["ffi"]
+    local real_tdb = package.loaded["pickthought.thought_db"]
+    local atomic_calls = 0  -- 计数:证明原子分支(ffi.C.open)确实被走到,而非降级 probe 路径。
+    package.loaded["ffi"] = {
+        os = "Linux",
+        abi = function() return true end,
+        cdef = function() end,  -- 无操作:fake 下无需真实声明
+        C = {
+            -- 模拟 C.open(O_CREAT|O_EXCL):目标已存在(磁盘)即返回 -1(EEXIST),
+            -- 否则原子占用(仅记录,不创建真实文件)返回伪 fd——这样后续 os.rename 在
+            -- Windows 测试机上也能成功(目标名未落真实文件)。
+            open = function(path, _flags, _mode)
+                atomic_calls = atomic_calls + 1
+                local f = io.open(path, "r")
+                if f then f:close(); return -1 end
+                return 3  -- 伪 fd
+            end,
+            close = function() return 0 end,
+        },
+    }
+    package.loaded["pickthought.thought_db"] = nil
+    local AtomicTDB = require("pickthought.thought_db")
+    package.loaded["ffi"] = real_ffi  -- 模块已捕获 fake,立即还原全局 ffi,避免污染其它用例
+
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("MAIN"); f:close()
+    end
+    local base = dir .. "/thoughts.db"
+    -- 预建"当前秒 salt 0"的旧备份,恰好命中 reserve_corrupt_main 首个候选 → 模拟目标被占用。
+    local old_target = base .. ".corrupt-" .. tostring(os.time()) .. "-0"
+    local of = io.open(old_target, "w"); of:write("OLD BACKUP PAYLOAD"); of:close()
+    T.ok(file_exists(old_target), "预建旧备份(当前秒 salt0)存在,恰好命中首个候选")
+
+    local target, err = AtomicTDB.isolate_corrupt(dir)
+    package.loaded["pickthought.thought_db"] = real_tdb  -- 还原模块缓存
+
+    T.ok(atomic_calls > 0, "原子分支(ffi.C.open)确实被走到,非降级 probe 路径")
+    T.ok(target ~= nil, "隔离成功(原子分支已启用)")
+    T.ok(target ~= old_target, "目标被占用 → 换新名(不覆盖旧备份)")
+    -- 旧备份内容原样保留(原子 open(O_EXCL) 在占用同名目标时失败,分支换名)。
+    local rf = io.open(old_target, "r"); local content = rf and rf:read("*a"); if rf then rf:close() end
+    T.ok(content == "OLD BACKUP PAYLOAD", "旧备份内容未被原子预留覆盖")
+    -- 新目标承载主库内容。
+    local nf = io.open(target, "r"); local ncontent = nf and nf:read("*a"); if nf then nf:close() end
+    T.ok(ncontent == "MAIN", "新目标承载主库内容")
+    rm_tmp(dir)
+end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -1,0 +1,64 @@
+-- ④ DB 完整性校验:integrity_check / checkpoint / 迁移追踪(user_version) / 损坏重建。
+-- stubs 的 SQLite mock 已支持 PRAGMA integrity_check(返回 {"ok"}) 与 user_version 读写。
+local ThoughtDB = require("pickthought.thought_db")
+local SQ3 = require("lua-ljsqlite3/init")
+
+local function fresh_db()
+    SQ3._reset()
+    return ThoughtDB.open("/book/dir")
+end
+
+T.case("integrity_check 健康库返回 true", function()
+    local db = fresh_db()
+    T.ok(db ~= nil, "open 成功")
+    local ok, msg = ThoughtDB.integrity_check(db)
+    T.ok(ok == true, "integrity_check 返回 true")
+    T.ok(msg == nil, "健康时无错误描述")
+    ThoughtDB.close(db)
+end)
+
+T.case("integrity_check 对 nil db 返回 false", function()
+    local ok, msg = ThoughtDB.integrity_check(nil)
+    T.ok(ok == false, "nil db → false")
+    T.ok(msg ~= nil, "带错误描述")
+end)
+
+T.case("checkpoint 不抛错且返回 true", function()
+    local db = fresh_db()
+    T.ok(ThoughtDB.checkpoint(db) == true, "checkpoint 返回 true")
+    ThoughtDB.close(db)  -- close 内部也会 checkpoint
+end)
+
+T.case("open 写入 user_version 迁移标记(SCHEMA_VERSION=1)", function()
+    local db = fresh_db()
+    T.ok(db ~= nil, "open 成功")
+    local store = SQ3._stores[ThoughtDB.db_path("/book/dir")]
+    T.ok(store ~= nil, "store 存在")
+    T.eq(store.user_version, 1, "user_version 写入为 1")
+    ThoughtDB.close(db)
+end)
+
+T.case("open 遇损坏库重建一次后成功(防无限递归)", function()
+    local orig = ThoughtDB.integrity_check
+    local calls = 0
+    ThoughtDB.integrity_check = function(_d)
+        calls = calls + 1
+        if calls == 1 then return false, "mock corrupt" end
+        return true
+    end
+    local db = ThoughtDB.open("/corrupt/book")
+    T.ok(db ~= nil, "重建后 open 成功")
+    T.eq(calls, 2, "恰好重建一次(第二次核验通过)")
+    ThoughtDB.integrity_check = orig
+    if db then ThoughtDB.close(db) end
+end)
+
+T.case("open 持续损坏时仅重试一次后返回 nil", function()
+    local orig = ThoughtDB.integrity_check
+    local calls = 0
+    ThoughtDB.integrity_check = function() calls = calls + 1; return false, "always corrupt" end
+    local db = ThoughtDB.open("/doomed/book")
+    T.ok(db == nil, "持续损坏 → open 返回 nil")
+    T.eq(calls, 2, "首次核验 + 重建后复核,共两次")
+    ThoughtDB.integrity_check = orig
+end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -653,3 +653,34 @@ T.case("open:无 lfs 退化 io.open 遇权限错误 → uncheckable 阻断自动
     T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建空库")
     rm_tmp(dir)
 end)
+
+
+-- 作者第7轮意见(2026-08-21):FFI 不可用/非 Linux 回退路径的 io.open 探测必须区分
+-- "明确不存在"与"权限/IO 错误"——后者立即失败、不进入换名循环(与 Linux 原子路径
+-- "仅 EEXIST 换名、其他错误立即失败"一致,避免最多 100000 次循环阻塞 Kindle),
+-- 且 .isolated 标记保留阻断自动建库、主库不被移动。
+T.case("隔离回退路径(无 FFI):io.open 权限错误 → 立即失败,只试 1 次,标记保留", function()
+    local dir = tmp_dir()
+    local f = io.open(dir .. "/thoughts.db", "w"); f:write("MAIN"); f:close()
+    -- mock io.open:.isolated 标记读写放行;.corrupt-* 候选探测返回权限错误。
+    local real_io_open = io.open
+    local probe_calls = 0
+    io.open = function(p, mode)
+        if tostring(p):find("%.isolated$") then return real_io_open(p, mode) end
+        if tostring(p):find("%.corrupt%-") then
+            probe_calls = probe_calls + 1
+            return nil, "Permission denied"
+        end
+        return real_io_open(p, mode)
+    end
+    local target, err = ThoughtDB.isolate_corrupt(dir)
+    io.open = real_io_open
+
+    T.ok(target == nil, "权限错误 → 隔离失败")
+    T.ok(tostring(err):find("无法探测") or tostring(err):find("重命名失败"),
+        "错误含失败原因: " .. tostring(err))
+    T.eq(probe_calls, 1, "只尝试 1 次即中止,不进入换名循环(不阻塞 Kindle)")
+    T.ok(file_exists(dir .. "/thoughts.db.isolated"), ".isolated 标记保留(阻断自动重建)")
+    T.ok(file_exists(dir .. "/thoughts.db"), "主库未被移动(保护原库)")
+    rm_tmp(dir)
+end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -6,7 +6,19 @@
 -- wal_checkpoint(返回 {0,0,0}) 与 user_version 读写。
 local ThoughtDB = require("pickthought.thought_db")
 local SQ3 = require("lua-ljsqlite3/init")
-local lfs = require("lfs")
+
+-- 跨平台临时目录(替代 lfs):CI/Linux 用 POSIX,Windows 回退 cmd(作者第3轮意见 #1:
+-- 测试不得依赖 lfs,也避免仅依赖 Windows rmdir /s /q)。
+local SEP = package.config:sub(1, 1)  -- "\\" on Windows
+local function sh(cmd) return os.execute(cmd) == 0 end
+local function mkdir_p(d)
+    if SEP == "\\" then return sh('cmd /c mkdir "' .. d .. '" >nul 2>nul') end
+    return sh('mkdir -p "' .. d .. '" 2>/dev/null')
+end
+local function rm_rf(d)
+    if SEP == "\\" then return sh('cmd /c rmdir /s /q "' .. d .. '" >nul 2>nul') end
+    return sh('rm -rf "' .. d .. '" 2>/dev/null')
+end
 
 local function fresh_db()
     SQ3._reset()
@@ -29,29 +41,13 @@ local function spy_os()
 end
 
 -- 真实临时目录(用于验证 os.rename 真的移动了文件,而非只调用了 API)。
--- 跨平台创建(lfs.mkdir,不依赖 Windows mkdir)。
 local function tmp_dir()
     local d = "tests/_iso_tmp_" .. tostring(os.time()) .. "_" .. tostring(math.floor(math.random() * 1e7))
-    pcall(lfs.mkdir, d)
+    mkdir_p(d)
     return d
 end
--- 跨平台递归删除(不依赖 Windows rmdir /s /q;用 lfs 遍历后逐文件/目录删除)。
-local function rm_tmp(d)
-    local function remove_recursive(path)
-        local mode = lfs.attributes(path, "mode")
-        if mode == "directory" then
-            for name in lfs.dir(path) do
-                if name ~= "." and name ~= ".." then
-                    remove_recursive(path .. "/" .. name)
-                end
-            end
-            lfs.rmdir(path)
-        else
-            os.remove(path)
-        end
-    end
-    pcall(remove_recursive, d)
-end
+-- 删除真实临时目录(跨平台,不依赖 lfs / Windows rmdir /s /q)。
+local function rm_tmp(d) rm_rf(d) end
 -- 真实文件中是否仍存在(存在返回 true)。
 local function file_exists(p)
     local f = io.open(p, "r"); if f then f:close(); return true end
@@ -318,11 +314,61 @@ T.case("隔离目标名唯一:预建同名 .corrupt-* 不被覆盖", function()
     local old_target = base .. ".corrupt-" .. tostring(old_ts) .. "-0"
     local of = io.open(old_target, "w"); of:write("OLD BACKUP"); of:close()
     T.ok(file_exists(old_target), "预建旧备份存在")
-    -- 触发隔离:unique_corrupt_target 应避开已存在的 old_target,换新名。
+    -- 触发隔离:reserve_corrupt_main 应避开已存在的 old_target,换新名。
     local target, err = ThoughtDB.isolate_corrupt(dir)
     T.ok(target ~= nil, "隔离成功")
     T.ok(target ~= old_target, "新目标名不同于旧备份(避免覆盖)")
     T.ok(file_exists(old_target), "旧备份未被覆盖,仍保留")
     T.ok(file_exists(target), "新隔离目标存在")
+    rm_tmp(dir)
+end)
+
+-- 作者第3轮意见 #4:直接覆盖 integrity_check 的 prepare/step 异常路径,
+-- 而非整体替换函数。命中 `if not stmt then error(...)` 与 stmt:step() 抛错透传。
+T.case("integrity_check:prepare 返回 nil 直接抛错(prepare 异常路径)", function()
+    local fake = { prepare = function() return nil end, close = function() end }
+    local ok, err = pcall(ThoughtDB.integrity_check, fake)
+    T.ok(not ok, "prepare 返回 nil → integrity_check 抛错")
+    T.ok(err ~= nil and tostring(err):find("prepare"), "错误含 prepare")
+end)
+
+T.case("integrity_check:stmt:step 抛错被透传为过程失败", function()
+    local fake = {
+        prepare = function()
+            return { step = function() error("SQLITE_IOERR") end, close = function() end }
+        end,
+        close = function() end,
+    }
+    local ok, err = pcall(ThoughtDB.integrity_check, fake)
+    T.ok(not ok, "step 抛错 → integrity_check 抛错(被 open 当作过程失败)")
+    T.ok(err ~= nil and tostring(err):find("SQLITE_IOERR"), "透传底层错误")
+end)
+
+-- 作者第3轮意见 #3:sidecar 无法检查(权限/IO)时不能误判为"不存在"而静默跳过,
+-- 必须保守地尝试归档,失败时返回错误(避免留下未归档文件)。
+T.case("隔离:sidecar 无法检查(权限/IO)时保守报错,不静默跳过", function()
+    local dir = tmp_dir()
+    for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
+        local f = io.open(dir .. "/" .. name, "w"); f:write("x"); f:close()
+    end
+    -- 注入 mock lfs:对 -shm 返回无法检查(Permission denied),模拟权限/IO 错误。
+    local old_lfs = package.loaded["libs/libkoreader-lfs"]
+    package.loaded["libs/libkoreader-lfs"] = {
+        attributes = function(p)
+            if p:find("%-shm$") then return nil, "Permission denied" end
+            return { mode = "file" }
+        end,
+    }
+    -- -shm 归档失败(模拟):无法检查 → 保守尝试 → 失败 → 必须报错而非跳过。
+    local o_rn = os.rename
+    os.rename = function(a, b)
+        if b:find("-shm$") then return nil, "mock shm fail" end
+        return o_rn(a, b)
+    end
+    local target, err = ThoughtDB.isolate_corrupt(dir)
+    os.rename = o_rn
+    package.loaded["libs/libkoreader-lfs"] = old_lfs
+    T.ok(target == nil, "无法确认 sidecar 状态时隔离报错(不静默跳过)")
+    T.ok(err ~= nil and tostring(err):find("sidecar"), "错误含 sidecar")
     rm_tmp(dir)
 end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -1,11 +1,24 @@
--- ④ DB 完整性校验:integrity_check / checkpoint / 迁移追踪(user_version) / 损坏重建。
--- stubs 的 SQLite mock 已支持 PRAGMA integrity_check(返回 {"ok"}) 与 user_version 读写。
+-- ④ DB 完整性校验:integrity_check / checkpoint / 迁移追踪(user_version) / 损坏隔离。
+-- 作者评审意见:open 必须区分"过程失败"与"确认损坏"——
+--   过程失败(I/O、busy/locked、prepare/step 异常):保留原库,绝不删;
+--   确认损坏:隔离(.corrupt-*)而非删除,绝不静默重建空库。
+-- stubs 的 SQLite mock 已支持 PRAGMA integrity_check(返回 {"ok"})、
+-- wal_checkpoint(返回 {0,0,0}) 与 user_version 读写。
 local ThoughtDB = require("pickthought.thought_db")
 local SQ3 = require("lua-ljsqlite3/init")
 
 local function fresh_db()
     SQ3._reset()
     return ThoughtDB.open("/book/dir")
+end
+
+-- 单测内 spy os.rename / os.remove,返回计数与还原闭包,用于断言"不删库/确实隔离"。
+local function spy_os()
+    local c = { rename = 0, remove = 0 }
+    local o_rn, o_rm = os.rename, os.remove
+    os.rename = function(...) c.rename = c.rename + 1; return o_rn(...) end
+    os.remove = function(...) c.remove = c.remove + 1; return o_rm(...) end
+    return c, function() os.rename, os.remove = o_rn, o_rm end
 end
 
 T.case("integrity_check 健康库返回 true", function()
@@ -23,7 +36,7 @@ T.case("integrity_check 对 nil db 返回 false", function()
     T.ok(msg ~= nil, "带错误描述")
 end)
 
-T.case("checkpoint 不抛错且返回 true", function()
+T.case("checkpoint 不抛错且返回 true(读取真实 status=0)", function()
     local db = fresh_db()
     T.ok(ThoughtDB.checkpoint(db) == true, "checkpoint 返回 true")
     ThoughtDB.close(db)  -- close 内部也会 checkpoint
@@ -38,27 +51,49 @@ T.case("open 写入 user_version 迁移标记(SCHEMA_VERSION=1)", function()
     ThoughtDB.close(db)
 end)
 
-T.case("open 遇损坏库重建一次后成功(防无限递归)", function()
-    local orig = ThoughtDB.integrity_check
-    local calls = 0
-    ThoughtDB.integrity_check = function(_d)
-        calls = calls + 1
-        if calls == 1 then return false, "mock corrupt" end
-        return true
-    end
-    local db = ThoughtDB.open("/corrupt/book")
-    T.ok(db ~= nil, "重建后 open 成功")
-    T.eq(calls, 2, "恰好重建一次(第二次核验通过)")
-    ThoughtDB.integrity_check = orig
+T.case("open 健康库:正常返回 db,不触发隔离/删除", function()
+    local c, restore = spy_os()
+    local db = ThoughtDB.open("/book/healthy")
+    restore()
+    T.ok(db ~= nil, "健康库 open 成功")
+    T.ok(c.rename == 0 and c.remove == 0, "健康库不隔离不删除")
     if db then ThoughtDB.close(db) end
 end)
 
-T.case("open 持续损坏时仅重试一次后返回 nil", function()
+T.case("open 遇确认损坏:隔离(.corrupt-*)而非删除,返回 nil", function()
     local orig = ThoughtDB.integrity_check
-    local calls = 0
-    ThoughtDB.integrity_check = function() calls = calls + 1; return false, "always corrupt" end
-    local db = ThoughtDB.open("/doomed/book")
-    T.ok(db == nil, "持续损坏 → open 返回 nil")
-    T.eq(calls, 2, "首次核验 + 重建后复核,共两次")
+    ThoughtDB.integrity_check = function(_d) return false, "mock corrupt" end
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open("/corrupt/book")
+    restore()
+    T.ok(db == nil, "确认损坏 → open 返回 nil(不静默重建空库)")
+    T.ok(err ~= nil and tostring(err):find("隔离"), "错误描述含'隔离'")
+    T.ok(c.rename >= 1, "损坏库被重命名隔离(.corrupt-*)")
+    T.ok(c.remove == 0, "绝不调用 os.remove 删除想法数据")
+    ThoughtDB.integrity_check = orig
+end)
+
+T.case("open 遇核验过程失败(busy/prepare 异常):保留原库,不删", function()
+    local orig = ThoughtDB.integrity_check
+    ThoughtDB.integrity_check = function(_d) error("mock process failure: SQLITE_BUSY") end
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open("/busy/book")
+    restore()
+    T.ok(db == nil, "过程失败 → open 返回 nil")
+    T.ok(err ~= nil and tostring(err):find("过程失败"), "错误描述含'过程失败'")
+    T.ok(c.rename == 0, "过程失败不触发隔离/重命名")
+    T.ok(c.remove == 0, "过程失败绝不删除想法数据")
+    ThoughtDB.integrity_check = orig
+end)
+
+T.case("open 隔离失败(无法重命名)时显式报错,不静默空库", function()
+    local orig = ThoughtDB.integrity_check
+    ThoughtDB.integrity_check = function(_d) return false, "mock corrupt" end
+    local o_rn = os.rename
+    os.rename = function() return nil, "mock rename fail" end  -- 模拟重命名失败
+    local db, err = ThoughtDB.open("/isolatefail/book")
+    os.rename = o_rn
+    T.ok(db == nil, "隔离失败 → open 返回 nil")
+    T.ok(err ~= nil and tostring(err):find("隔离失败"), "错误描述含'隔离失败'")
     ThoughtDB.integrity_check = orig
 end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -500,35 +500,77 @@ T.case("open:integrity_check 格式异常 → 过程失败(保留原库,不隔�
     ThoughtDB.integrity_check = orig
 end)
 
--- 作者第5轮意见 2026-08-19:原子无覆盖路径在 Kindle Linux 必须真实启用,且测试须覆盖原子分支
--- (此前 CI 走降级 probe 路径,未验证 O_CREAT|O_EXCL 原子占用)。
--- 本用例注入 fake ffi(os="Linux" + C.open/C.close 模拟原子占用)强制走原子分支,验证:
---   ① 目标被占用(已存在 .corrupt-*)时换新名;② 旧 .corrupt-* 内容不被覆盖。
-T.case("原子预留(Linux 分支):目标被占用时换名,旧备份内容不覆盖", function()
-    -- 注入 fake ffi 强制启用原子路径,再重新加载模块(仅本用例作用域,加载后还原全局 ffi)。
+-- 完整模拟 Linux 原子预留的 fake ffi(作者第6轮意见 #3:必须真实模拟占位状态、错误码
+-- 与 fd 生命周期,而非只统计调用次数):
+--   - C.open(O_CREAT|O_EXCL) 语义:目标已存在(真实文件或本流程已占位)→ -1 + errno=EEXIST(17);
+--     成功 → 分配伪 fd 并记录占位(占位仅内存态,不落真实文件,使 Windows 上后续
+--     os.rename 能成功——与真实 Linux 的"rename 覆盖空占位"等价)。
+--   - errno_map[path] 可注入非 EEXIST 错误码(权限/磁盘等)模拟异常。
+--   - C.close 记录被关闭 fd 对应路径当时的文件内容:若 close 发生在 rename 完成之后,
+--     该路径应已承载主库内容("MAIN")——据此断言"fd 保持到 rename 完成后才关闭"。
+local function make_fake_ffi(errno_map)
+    local state = {
+        open_calls = 0, close_calls = 0, success_calls = 0,
+        fds = {}, opened = {}, errno = 0,
+        closed_content = nil,  -- 最近一次 close 时该路径的内容(验证 close 时机)
+    }
+    local C = {
+        open = function(path, _flags, _mode)
+            state.open_calls = state.open_calls + 1
+            state.errno = 0
+            -- errno_map 支持按路径精确注入,或 "*" 通配注入(对所有候选生效)。
+            local injected = errno_map and (errno_map[path] or errno_map["*"])
+            if injected then
+                state.errno = injected
+                return -1
+            end
+            local f = io.open(path, "r")
+            if f then f:close(); state.errno = 17; return -1 end  -- 已存在(EEXIST)
+            if state.opened[path] then state.errno = 17; return -1 end
+            state.opened[path] = true
+            state.success_calls = state.success_calls + 1
+            local fd = 10 + state.success_calls
+            state.fds[fd] = path
+            return fd
+        end,
+        close = function(fd)
+            state.close_calls = state.close_calls + 1
+            local p = state.fds[fd]
+            if p then
+                local f = io.open(p, "r")
+                if f then
+                    state.closed_content = f:read("*a"); f:close()
+                else
+                    state.closed_content = nil
+                end
+                state.fds[fd] = nil
+            end
+            return 0
+        end,
+    }
+    return { os = "Linux", abi = function() return true end, cdef = function() end,
+        C = C, errno = function() return state.errno end, _state = state }
+end
+
+-- 注入 fake ffi 并重新加载模块(仅用例作用域,结束后还原),返回 (模块, fake)。
+local function with_fake_ffi(errno_map)
     local real_ffi = package.loaded["ffi"]
     local real_tdb = package.loaded["pickthought.thought_db"]
-    local atomic_calls = 0  -- 计数:证明原子分支(ffi.C.open)确实被走到,而非降级 probe 路径。
-    package.loaded["ffi"] = {
-        os = "Linux",
-        abi = function() return true end,
-        cdef = function() end,  -- 无操作:fake 下无需真实声明
-        C = {
-            -- 模拟 C.open(O_CREAT|O_EXCL):目标已存在(磁盘)即返回 -1(EEXIST),
-            -- 否则原子占用(仅记录,不创建真实文件)返回伪 fd——这样后续 os.rename 在
-            -- Windows 测试机上也能成功(目标名未落真实文件)。
-            open = function(path, _flags, _mode)
-                atomic_calls = atomic_calls + 1
-                local f = io.open(path, "r")
-                if f then f:close(); return -1 end
-                return 3  -- 伪 fd
-            end,
-            close = function() return 0 end,
-        },
-    }
+    local fake = make_fake_ffi(errno_map)
+    package.loaded["ffi"] = fake
     package.loaded["pickthought.thought_db"] = nil
     local AtomicTDB = require("pickthought.thought_db")
     package.loaded["ffi"] = real_ffi  -- 模块已捕获 fake,立即还原全局 ffi,避免污染其它用例
+    return AtomicTDB, fake, function() package.loaded["pickthought.thought_db"] = real_tdb end
+end
+
+-- 作者第5轮意见 2026-08-19:原子无覆盖路径在 Kindle Linux 必须真实启用,且测试须覆盖原子分支
+-- (此前 CI 走降级 probe 路径,未验证 O_CREAT|O_EXCL 原子占用)。
+-- 第6轮意见(2026-08-20):fake 须完整模拟占位状态、错误码与 fd 生命周期。
+-- 本用例验证:① 目标被占用(EEXIST)时换新名;② 旧 .corrupt-* 内容不被覆盖;
+-- ③ 占位 fd 保持到 rename 完成之后才关闭(close 时目标已承载主库内容)。
+T.case("原子预留(Linux 分支):目标被占用时换名,旧备份不覆盖,fd 保持到 rename 后关闭", function()
+    local AtomicTDB, fake, restore_tdb = with_fake_ffi(nil)
 
     local dir = tmp_dir()
     for _, name in ipairs({ "thoughts.db", "thoughts.db-wal", "thoughts.db-shm" }) do
@@ -541,9 +583,9 @@ T.case("原子预留(Linux 分支):目标被占用时换名,旧备份内容不�
     T.ok(file_exists(old_target), "预建旧备份(当前秒 salt0)存在,恰好命中首个候选")
 
     local target, err = AtomicTDB.isolate_corrupt(dir)
-    package.loaded["pickthought.thought_db"] = real_tdb  -- 还原模块缓存
+    restore_tdb()
 
-    T.ok(atomic_calls > 0, "原子分支(ffi.C.open)确实被走到,非降级 probe 路径")
+    T.ok(fake._state.open_calls > 0, "原子分支(ffi.C.open)确实被走到,非降级 probe 路径")
     T.ok(target ~= nil, "隔离成功(原子分支已启用)")
     T.ok(target ~= old_target, "目标被占用 → 换新名(不覆盖旧备份)")
     -- 旧备份内容原样保留(原子 open(O_EXCL) 在占用同名目标时失败,分支换名)。
@@ -552,5 +594,54 @@ T.case("原子预留(Linux 分支):目标被占用时换名,旧备份内容不�
     -- 新目标承载主库内容。
     local nf = io.open(target, "r"); local ncontent = nf and nf:read("*a"); if nf then nf:close() end
     T.ok(ncontent == "MAIN", "新目标承载主库内容")
+    -- 占位 fd 生命周期(第6轮意见 #2):close 发生在 rename 之后——close 时该路径应已
+    -- 承载主库内容(占位已被 rename 覆盖),而非空占位。
+    T.eq(fake._state.closed_content, "MAIN", "fd 保持到 rename 完成后才关闭(close 时目标已承载主库内容)")
+    -- 每次成功 open 最终都有对应 close(无 fd 泄漏);EEXIST 失败尝试不产生 fd,不计入。
+    T.ok(fake._state.close_calls >= fake._state.success_calls, "成功占位的 fd 均已关闭")
+    rm_tmp(dir)
+end)
+
+-- 作者第6轮意见 #1:atomic_claim 必须读取 errno,仅 EEXIST 换名重试;权限/磁盘/IO 错误
+-- 立即中止(绝不盲目循环 100000 次阻塞 Kindle),且隔离标记保留阻断自动重建。
+T.case("原子预留:非 EEXIST 错误(errno=EACCES)立即中止,不换名不循环,标记保留", function()
+    -- 模块 require 时捕获 ATOMIC_OPEN,故 errno 注入须在加载前(通配 "*" 对所有候选生效)。
+    local AtomicTDB, fake, restore_tdb = with_fake_ffi({ ["*"] = 13 })  -- EACCES:权限不足
+
+    local dir = tmp_dir()
+    local f = io.open(dir .. "/thoughts.db", "w"); f:write("MAIN"); f:close()
+    local target, err = AtomicTDB.isolate_corrupt(dir)
+    restore_tdb()
+
+    T.ok(target == nil, "非 EEXIST 错误 → 隔离失败")
+    T.ok(tostring(err):find("目标占用失败") or tostring(err):find("重命名失败"),
+        "错误含失败原因: " .. tostring(err))
+    T.eq(fake._state.open_calls, 1, "只尝试 1 次即中止,不盲目换名循环")
+    T.ok(file_exists(dir .. "/thoughts.db.isolated"), ".isolated 标记保留(阻断自动重建)")
+    T.ok(file_exists(dir .. "/thoughts.db"), "主库未被移动(保护原库)")
+    rm_tmp(dir)
+end)
+
+-- 作者第6轮意见 #4:path_exists_distinct 在 lfs 不可用时退化的 io.open 也要区分
+-- "不存在"与"权限/IO 错误"(后者 → uncheckable → 阻断自动建库,不误判为不存在)。
+T.case("open:无 lfs 退化 io.open 遇权限错误 → uncheckable 阻断自动重建", function()
+    local dir = tmp_dir()
+    -- 让主库路径是一个"目录":io.open(dir, "r") 打不开且错误不是 "No such file" → uncheckable。
+    mkdir_p(dir .. "/thoughts.db")
+    -- 移除 lfs(loaded + preload),强制 path_exists_distinct 走 io.open 退化分支。
+    local old_loaded = package.loaded["libs/libkoreader-lfs"]
+    local old_preload = package.preload["libs/libkoreader-lfs"]
+    package.loaded["libs/libkoreader-lfs"] = nil
+    package.preload["libs/libkoreader-lfs"] = nil
+    local c, restore = spy_os()
+    local db, err = ThoughtDB.open(dir)
+    restore()
+    package.loaded["libs/libkoreader-lfs"] = old_loaded
+    package.preload["libs/libkoreader-lfs"] = old_preload
+
+    T.ok(db == nil, "主库无法检查 → open 返回 nil(阻断)")
+    T.ok(tostring(err):find("无法确认"), "错误含'无法确认': " .. tostring(err))
+    T.ok(c.rename == 0 and c.remove == 0, "阻断时不隔离不删除")
+    T.ok(not file_exists(dir .. "/thoughts.db"), "未自动创建空库")
     rm_tmp(dir)
 end)

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -662,6 +662,15 @@ end)
 T.case("隔离回退路径(无 FFI):io.open 权限错误 → 立即失败,只试 1 次,标记保留", function()
     local dir = tmp_dir()
     local f = io.open(dir .. "/thoughts.db", "w"); f:write("MAIN"); f:close()
+    -- 强制走回退路径:CI(Linux + LuaJIT)下 ffi.os=="Linux" 会启用原子路径
+    -- (ffi.C.open),io.open mock 不会触发。注入 fake ffi(os="Windows") 重载模块,
+    -- 使 ATOMIC_OPEN=nil → reserve_corrupt_main 走 io.open 退化探测(作者第7轮边界)。
+    local real_ffi = package.loaded["ffi"]
+    local real_tdb = package.loaded["pickthought.thought_db"]
+    package.loaded["ffi"] = { os = "Windows" }
+    package.loaded["pickthought.thought_db"] = nil
+    local DegradedTDB = require("pickthought.thought_db")
+    package.loaded["ffi"] = real_ffi
     -- mock io.open:.isolated 标记读写放行;.corrupt-* 候选探测返回权限错误。
     local real_io_open = io.open
     local probe_calls = 0
@@ -673,8 +682,9 @@ T.case("隔离回退路径(无 FFI):io.open 权限错误 → 立即失败,只试
         end
         return real_io_open(p, mode)
     end
-    local target, err = ThoughtDB.isolate_corrupt(dir)
+    local target, err = DegradedTDB.isolate_corrupt(dir)
     io.open = real_io_open
+    package.loaded["pickthought.thought_db"] = real_tdb  -- 还原模块缓存
 
     T.ok(target == nil, "权限错误 → 隔离失败")
     T.ok(tostring(err):find("无法探测") or tostring(err):find("重命名失败"),

--- a/tests/test_thought_db_integrity.lua
+++ b/tests/test_thought_db_integrity.lua
@@ -624,18 +624,26 @@ end)
 
 -- 作者第6轮意见 #4:path_exists_distinct 在 lfs 不可用时退化的 io.open 也要区分
 -- "不存在"与"权限/IO 错误"(后者 → uncheckable → 阻断自动建库,不误判为不存在)。
+-- 注:不依赖"目录当不可读文件"(Linux/POSIX 允许 open 目录,CI 上不成立),
+-- 改用 mock io.open 精确返回 "Permission denied",跨平台可靠。
 T.case("open:无 lfs 退化 io.open 遇权限错误 → uncheckable 阻断自动重建", function()
     local dir = tmp_dir()
-    -- 让主库路径是一个"目录":io.open(dir, "r") 打不开且错误不是 "No such file" → uncheckable。
-    mkdir_p(dir .. "/thoughts.db")
     -- 移除 lfs(loaded + preload),强制 path_exists_distinct 走 io.open 退化分支。
     local old_loaded = package.loaded["libs/libkoreader-lfs"]
     local old_preload = package.preload["libs/libkoreader-lfs"]
     package.loaded["libs/libkoreader-lfs"] = nil
     package.preload["libs/libkoreader-lfs"] = nil
+    -- mock io.open:.isolated 标记=不存在;主库路径=权限错误(非 no such file → uncheckable)。
+    local real_io_open = io.open
+    io.open = function(p, mode)
+        if tostring(p):find("%.isolated$") then return nil, "No such file or directory" end
+        if tostring(p):find("thoughts%.db$") then return nil, "Permission denied" end
+        return real_io_open(p, mode)
+    end
     local c, restore = spy_os()
     local db, err = ThoughtDB.open(dir)
     restore()
+    io.open = real_io_open
     package.loaded["libs/libkoreader-lfs"] = old_loaded
     package.preload["libs/libkoreader-lfs"] = old_preload
 

--- a/tests/test_thoughts.lua
+++ b/tests/test_thoughts.lua
@@ -112,3 +112,27 @@ T.case("Thoughts.group_abstract 取首条摘要", function()
     T.eq(Thoughts.group_abstract(group), "原文摘要", "摘要取自首条")
     T.eq(Thoughts.group_abstract({ texts = { { content = "x", abstract = "" } } }), "", "无摘要返空")
 end)
+
+-- 作者第8轮意见 #3:ThoughtDB.open 的具体错误必须透传到 Thoughts.save/find,
+-- 不得被吃成通用的"想法数据库不可用"(便于真机定位是损坏隔离/权限/迁移失败等)。
+T.case("Thoughts.open_db 透传 ThoughtDB.open 的具体错误(作者第8轮 #3)", function()
+    SQ3._reset()
+    local store = store_with("/t/errprop")
+    -- mock ThoughtDB.open 返回 nil + 具体错误(如损坏隔离/迁移失败描述)。
+    local ThoughtDB = require("pickthought.thought_db")
+    local orig_open = ThoughtDB.open
+    local SPECIFIC = "损坏库已隔离到 .corrupt-*,请重同步(target=...) "
+    ThoughtDB.open = function(_dir) return nil, SPECIFIC end
+
+    local cnt, serr = Thoughts.save(store, "b", "1", {
+        { range = "0-7", texts = { { content = "x", author = "a", review_id = "" } } },
+    })
+    T.ok(cnt == nil, "save 在 open 失败时返回 nil")
+    T.ok(serr == SPECIFIC, "save 透传具体错误(非通用文案): " .. tostring(serr))
+
+    local grp, ferr = Thoughts.find(store, "b", "1", "0-7")
+    T.ok(grp == nil, "find 在 open 失败时返回 nil")
+    T.ok(ferr == SPECIFIC, "find 透传具体错误: " .. tostring(ferr))
+
+    ThoughtDB.open = orig_open
+end)


### PR DESCRIPTION
## 优化目标

本 PR 在 SQLite 连接 LRU（PR④ / PR#11）落地的基础上，补充**数据库完整性校验与 WAL 折叠**，提升本地 SQLite 在 FAT32 SD 卡（KPW3 等低性能墨水屏）上的健壮性。

背景来自本地可行性评估（对应更新日志见 fork 仓库 `main` 分支的 `audit/10-db-integrity-changelog.html`）：pickthought 当前 SQLite 层已有 WAL + 事务 + 文件清理，但缺 `integrity_check`、迁移追踪、WAL 折叠。FAT32 SD 卡在意外断电 / 热插拔时易产生损坏页，本 PR 补齐这三块。

## 本 PR 如何达成目标

- **打开即核验（防损坏库拖垮开书）**：`thought_db.lua` 的 `open` 打开后先跑 `PRAGMA integrity_check`，并**严格区分两类结果**（作者评审阻断项）：
  - **核验过程失败**（prepare/step 抛错、I/O、busy/locked、格式异常）——视为"非损坏"，**保留原库、关闭句柄、返回错误**，绝不删库或重开空库。
  - **确认损坏**（integrity_check 明确报坏）——**隔离而非删除**：用 `os.rename` 把 `.db/-wal/-shm` 重命名为 `.corrupt-<ts>` 保留证据，返回错误提示"想法可由本地注入源（离线缓存）重建"，**绝不静默重建空库**。
- **迁移追踪（user_version）**：新增 `SCHEMA_VERSION` 常量与 `get_user_version` / `set_user_version`，用 `PRAGMA user_version` 记录 schema 版本；预留 `MIGRATIONS` 分发点（当前仅补版本号，不做破坏性迁移，明确"无线上账号/云同步，想法可由本地注入源重建"）。
- **关闭前折叠 WAL（回收 -wal/-shm）**：`close` 关闭前执行 `PRAGMA wal_checkpoint(TRUNCATE)`；`checkpoint` 现读取 PRAGMA **真实返回** `(total, ckpt, status)`，`status ~= 0`（如 busy）记 warn 并判失败，不再把 busy 当成功。

## 作者评审意见（CHANGES_REQUESTED）落实

| # | 作者意见 | 落实 |
|---|---|---|
| 阻断 | `open` 把"过程异常"与"确认损坏"混为一谈，一律 `os.remove` 删库 → 想法不可逆丢失 | `open` 区分两类失败；过程失败保留原库返回错误；确认损坏 `os.rename` 隔离为 `.corrupt-<ts>`，绝不删除 |
| 次要① | `checkpoint` 只判 Lua 抛错、没读 SQLite 实际返回 | `checkpoint` 解析 `(total,ckpt,status)`，busy/失败判失败并 warn |
| 次要② | `user_version` 只写版本号、无迁移分发逻辑 | 明确"仅版本标记 + 预留 MIGRATIONS 分发点"，注释说明无结构性迁移原因 |
| 流程 | 基于当前 `main` 重放 | 已 rebase 到 `upstream/main` `38c352c`（线性无冲突，仅 `run.lua` 测试清单合并） |

## 详细说明

### 改动
- `thought_db.lua`：新增 `isolate_corrupt`；`integrity_check` 改为"健康返回 true / 确认损坏返回 (false,detail) / 过程失败抛错"的清晰契约；`open` 改为「打开即核验 + 两类失败分流（保留/隔离）」；`checkpoint` 改为读取真实 status；`ensure_schema` 增加 `MIGRATIONS` 预留分发点。
- `tests/stubs.lua`：mock 扩展 `integrity_check`(返回 {"ok"}) / `wal_checkpoint`(返回 {0,0,0}) / `user_version` 读写。
- `tests/run.lua`：注册 `test_thought_db_integrity`（合并上游测试清单冲突）。
- `tests/test_thought_db_integrity.lua`：8 case——校验通过 / nil db / checkpoint 成功 / user_version 写入 / 健康库不隔离不删除 / 确认损坏隔离且绝不删 / 过程失败保留库且不删 / 隔离失败显式报错。

### 影响范围
仅 `thought_db.lua` 的打开 / 关闭与只读 API；不动注入热路径、不动数据 schema 形状（`review_items` 表定义未变）；多书（D）逻辑未引入。`remove_db` 仍保留为显式公共 API（供用户主动清缓存），`open` 不再调用它。

### 校验
- LuaJIT 语法：OK
- 单测（本分支）：**全量 204 passed / 0 failed**（含 DB 完整性 29/0；本地 LuaJIT 语法校验绿）。本仓库无 CI，校验以本地 LuaJIT 全量测试为准。
- 加载期核验：类顺序 OK / 无 `local _` 遮蔽 / 代理 `LOAD_OK`
- 关键安全断言：`os.remove` 在损坏/过程失败路径**均未被调用**（测试 spy 验证）

## 分支说明

本 PR（`pr/db-integrity`）基于 `upstream/main`（`38c352c`）重放，仅改动 `thought_db.lua` + 测试，与 #9~#13、#17（③ 滑窗降级）零文件冲突，可独立评审 / 合入。



## 评审二轮（2026-08-14）落实（提交 82af014）

作者（Mr54233）在 CHANGES_REQUESTED 中追加的六处意见，已全部落实：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | `remove_db` 未清理 `.isolated` 残留，重开后旧隔离标记仍生效 | ✅ `remove_db` 一并清除 `.isolated` 标记文件 |
| ② | `isolate_corrupt` 仅 rename，未校验目标、未处理 -wal/-shm 同移 | ✅ 重写 `isolate_corrupt`：校验源存在、目标名唯一、连带 -wal/-shm 一并隔离 |
| ③ | `checkpoint` 只判 prepare 抛错，没读真实返回 | ✅ 读 `row[1]` 真实值 + `log==ckpt` 判定；busy/未完全折叠判失败并 warn |
| ④ | `do_open` 内仍调 `ensure_schema`，与"打开即核验"职责耦合 | ✅ `do_open` 去除 `ensure_schema` 调用，schema 仅在显式迁移路径处理 |
| ⑤ | `open` 缺"已隔离库"守卫，可能重复隔离/重复报错 | ✅ `open` 重写并加 `is_isolated` 守卫，隔离库直接返回明确错误 |
| ⑥ | 缺 `close_no_checkpoint` 旁路，测试/特殊场景无法跳过折叠 | ✅ 新增 `close_no_checkpoint`，保留显式关闭入口 |

- 真实文件级测试补强（非仅 mock）：`test_thought_db_integrity.lua` 8→14 用例，覆盖 rename 目标唯一、连带 -wal/-shm、is_isolated 守卫、close_no_checkpoint。
- 本分支 DB 完整性用例 **14/0**（分支基线较旧，全量待合入 upstream 后统一跑）。
- 配套更新日志：`audit/10-db-integrity-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。

## 评审三轮（2026-08-15 ~ 2026-08-17）落实（提交 9424a08 / d4aa811）

作者在 2026-08-15 ~ 08-17 连续给出两轮意见，聚焦"隔离流程任一步失败都不能让下一次 open 得到一个新的空库"这一核心不变量，并指出备份目标名非真正唯一、需区分"文件不存在"与"权限/IO 不可检查"：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | 备份目标名"探测后 rename"仍残留竞态窗口、可能覆盖已有备份 | ✅ `reserve_corrupt_main` 先 `io.open` 探测候选目标空闲、空闲才 `os.rename` 占用，占用即成功才返回；序号到顶换时间戳再次确认目标为空，杜绝覆盖旧备份 |
| ② | 隔离流程需显式区分"文件不存在"与"权限/IO 不可检查" | ✅ 新增 `path_exists_distinct`（`lfs.attributes` 错误码区分，返回 `(exists, state)`，state 为 `uncheckable` 时保守处理）；`isolate_corrupt` 主库 `uncheckable` → 保守报错中止 |
| ③ | 测试须直测 `integrity_check` 的 prepare/step 异常路径（而非整体替换函数） | ✅ 新增 `prepare` 返回 `nil` 直接 `error`、以及 `stmt:step` 抛错被透传为过程失败两条直测 |
| ④ | 测试不得依赖 `lfs` | ✅ 临时目录改为跨平台 `SEP`/`sh`/`mkdir_p`/`rm_rf`，去 `lfs` 依赖 |
| ⑤ | 修复测试桩隐患：`libs/libkoreader-lfs.attributes` 恒返回 `nil` 把全部路径误判为 `uncheckable` | ✅ 新桩忠实返回存在性（存在→属性表 / 不存在→`nil,"No such file or directory"`），使真实文件隔离用例由红转绿 |

- 本分支 DB 完整性用例随 upstream 前进统一：**195 passed / 0 failed**（含 DB 完整性 20/0，5 个真实文件隔离用例由红转绿）。

## 评审四轮（2026-08-19）落实（提交 5f57dd9，原子无覆盖预留+异常状态判定+格式校验）

作者（Mr54233）在 2026-08-18T11:27:10Z 的第4轮意见，要求把隔离流程最后几处"极端失败边界"补严：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | 损坏备份目标须**原子无覆盖**预留——探测后 rename 仍有竞态、且可能覆盖已有 `.corrupt-*` | ✅ 新增 `atomic_claim(target)`：Linux 下用 `ffi` 调 C `open(O_CREAT\|O_EXCL, 0600)` **原子占用**目标名（已存在即失败，绝不覆盖），非 Linux/无 ffi 退化为 `io.open` 探测+`os.rename`；`reserve_corrupt_main` 整体改用该原子预留，彻底消除 TOCTOU 与覆盖旧备份两类隐患 |
| ② | `open` 须区分"明确不存在"与"无法确认"（`.isolated` 读取失败 / 主库缺失但仍有孤立 sidecar 时，须阻断自动建空库） | ✅ 移除冗余 `is_isolated`，改由 `path_exists_distinct` 统一判定；`open` 前置守卫：`.isolated` 读取失败→保守阻断；主库状态无法确认→阻断；主库缺失但仍有孤立 sidecar（-wal/-shm）→阻断；仅"主库确缺失且无 sidecar"才允许新建 |
| ③ | 校验 `integrity_check` 的**返回格式**（非标准结果按过程失败处理，保留原库） | ✅ 新增格式检查：无结果行 / 结果行非表 / 首列非字符串 → 抛错，按"过程失败"处理（保留原库、不触发隔离），避免把格式异常误判为确认损坏 |

- 测试新增 8 用例（旧备份内容不被新预留覆盖、标记读取失败阻断、主库无法确认阻断、孤立 sidecar 阻断、正常新建放行、`integrity_check` 返回格式异常三类）。
- 全量测试 **204 passed / 0 failed**（含 DB 完整性 29/0）。
- 配套更新日志：`audit/10-db-integrity-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。

## 评审五轮（2026-08-20）落实（提交 3bef4aa，ffi.os 启用原子路径 + cdef + 原子分支测试）

作者（Mr54233）在 2026-08-19T14:07:18Z 的第5轮意见指出，第4轮虽改成"原子无覆盖预留"，但原子路径在 Kindle Linux 上实际从未启用，且测试未真正覆盖原子分支。本提交逐条修复：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | `atomic_claim()` 用 `ffi.abi("os") == "Linux"` 判断系统，但 `ffi.abi()` 返回布尔值，导致 Kindle Linux 永远走 `probe + os.rename` 降级路径，TOCTOU 竞态实际仍存在 | ✅ 改为 `ffi.os == "Linux"`（LuaJIT 正确的系统判断方式：`ffi.os` 为 `"Linux"/"Windows"/"OSX"` 字符串），确保 Kindle Linux 真实进入 `O_CREAT\|O_EXCL` 原子预留路径 |
| ② | 原子路径直接访问 `ffi.C.open` / `ffi.C.close`，但模块未声明这些 C 函数，加载期会报 `missing declaration for symbol 'open'` | ✅ 新增 `ffi.cdef` 声明 `open/close`；`cdef` 冲突时退化为 `nil`（走降级路径），不阻断加载 |
| ③ | 测试只验证了顺序场景，CI 实际走降级路径，未强制验证 Linux 原子预留 | ✅ `tests/test_thought_db_integrity.lua` 新增用例：注入 fake `ffi`（`os="Linux"` + `C.open/C.close` 模拟原子占用）强制走原子分支，验证目标被占用时换名、旧 `.corrupt-*` 内容不被覆盖，并以 `atomic_calls` 计数断言原子分支确实被走到（避免 CI 假绿） |

- 全量测试 **204 passed / 0 failed**（含 DB 完整性 29/0）。
- 配套更新日志：`audit/10-db-integrity-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。
- 数据安全方向已完整，剩余仅合并流程（squash + review）。请作者 flip CHANGES_REQUESTED 进入合并评估。


## 评审六轮（2026-08-20 晚）落实（提交 ebe5e96，errno 区分 + 占位 fd 生命周期 + 退化路径 uncheckable）

作者（Mr54233）在 2026-08-20T11:46:26Z 的第6轮意见指出，原子隔离还有 4 个极端文件系统边界。本提交逐条修复：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | `atomic_claim()` 把所有 `open()` 失败都当成目标已存在；权限不足/磁盘耗尽/IO 错误会一直尝试候选名，最多循环 100000 次阻塞 Kindle | ✅ 读取 `ffi.errno()`：仅 `errno==EEXIST(17)` 视为目标已存在、换名重试；其他错误立即返回，`reserve_corrupt_main` 遇非 EEXIST 直接中止；`.isolated` 标记已先行写入，保留阻断自动建库 |
| ② | 占位文件创建成功后立即关闭 fd，到 `rename()` 之间仍存在竞态（其他进程可能删除/替换占位文件，`rename()` 可能覆盖已有备份，失败后的 `os.remove()` 可能误删被替换文件） | ✅ `atomic_claim` 成功返回保持打开的 fd，`reserve` 在 `rename` 完成（或失败）后才关闭；`rename` 失败清理占位时仅删除本流程创建的 0 字节空占位，若已被替换成有内容文件则不动，避免误删他人数据 |
| ③ | fake FFI 测试只统计 `C.open` 调用，未真正创建/持有占位文件，无法验证 `O_EXCL`、fd 生命周期与异常路径 | ✅ fake ffi 完整模拟 `O_CREAT\|O_EXCL` 占位语义、errno 注入（支持通配）与 fd 生命周期——`close` 时检查目标已承载主库内容，证明 fd 保持到 `rename` 完成后才关闭；新增 EACCES 立即中止用例（`open` 只调 1 次、标记保留、主库未动） |
| ④ | `path_exists_distinct()` 在 lfs 未预加载时退回 `io.open`，权限错误与文件不存在混为一谈 | ✅ 显式 `pcall(require,"libs/libkoreader-lfs")`；lfs 不可用时退化 `io.open` 也据 err 文本区分「不存在」与「权限/IO 错误」（后者 → `uncheckable` → 阻断自动建库），新增无 lfs 退化路径权限错误用例 |

**rebase 到最新 main（v0.3.3 + 性能模式 435971b）**：cherry-pick 重放 9 个提交（`237a32d` 三轮收尾、`c1ad727` 五轮、`ebe5e96` 六轮等），零冲突；上游 #17 性能模式合入后新增 23 个测试随行。全量 **229 passed / 0 failed**（DB 完整性 31/0）。CI `quality / verify` 对 head `a25d885` **通过**（actions/runs/32379016027，含 mock io.open 跨平台修复），PR `mergeable_state=clean`。配套更新日志：`audit/10-db-integrity-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。请作者 flip CHANGES_REQUESTED 进入合并评估。


## 评审七轮（2026-08-21）落实（提交 e7bfbda，回退路径 io.open 错误区分 + migrate 异常保护）

作者（Mr54233）在 2026-08-21T12:51:23Z 的第7轮意见指出最后两处跨平台边界，全部落实：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | 无 FFI / 非 Linux 回退路径的 `io.open` 探测把权限/磁盘/IO 错误误判为「目标不存在」，会持续换名重试最多 100000 次阻塞 Kindle（与 Linux 原子路径「仅 EEXIST 换名」不一致） | ✅ 仅「明确不存在」（ENOENT / No such file / not exist）允许继续尝试；其他错误立即返回失败；`.isolated` 标记保留阻断自动建库、主库不被移动。新增「无 FFI 回退路径 io.open 权限错误 → 立即失败，只试 1 次，标记保留」用例（`probe_calls==1`） |
| ② | `migrate()` 吞掉迁移异常后继续写入 `user_version`（当前 `MIGRATIONS` 为空，暂不阻断；为未来迁移预留） | ✅ 任一级迁移失败立即中止并返回 `false`，调用方不再无条件 `set_user_version`——迁移未完成不得声称已升级，否则下次打开跳过必要迁移 |

**测试**：新增 1 用例（fake ffi 注入强制走退化分支，CI Linux 原子路径不再吞掉 io.open mock）。全量 **230 passed / 0 failed**。CI `quality / verify` 对 head `baa64d4` **通过**（actions/runs/32493997597，含 fake ffi 强制回退路径的跨平台修复），PR `mergeable_state=clean`。配套更新日志：`audit/10-db-integrity-changelog.html`（已同步至 fork `main`，不进本 PR diff）。请作者 flip CHANGES_REQUESTED 进入合并评估。

## 评审八轮（2026-08-22T09:42:32Z）落实（提交 edf562f，迁移失败契约 + 损坏隔离残留边界）

作者在第8轮指出四处残留边界，已逐条落实（仅 thought_db.lua + thoughts.lua + 测试，行为向后兼容）：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| ① | 损坏主库重命名失败应区分「原子预留路径」与「退化 probe 路径」，避免盲目循环最多 100000 次阻塞 Kindle | ✅ `reserve_corrupt_main` 新增 `ATOMIC_OPEN` 分支判定：原子路径（O_CREAT\|O_EXCL 已独占目标）下 rename 失败直接清理本流程空占位后返回失败、不进入换名循环；退化路径仅当目标被明确占用（竞态，ENOENT/No such file）才换名重试，权限/磁盘/IO 等其他错误立即失败。`.isolated` 标记由调用方保留阻断，主库不被移动 |
| ② | `path_exists_distinct` 退化 `io.open` 把空错误文本（err==""）与「不存在」等同，异常 I/O 下可能误建空库掩盖数据 | ✅ 仅匹配 `no such file`/`不存在` 才视为不存在；空错误文本落入 `uncheckable`，阻止自动创建新数据库 |
| ③ | `thoughts.lua` 的 `open_db` 丢弃了 `ThoughtDB.open` 的具体错误，真机只能看到通用「想法数据库不可用」，难以定位是损坏隔离/权限/迁移失败 | ✅ `open_db` 改为 `db, open_err = ThoughtDB.open(...)`，失败返回 `nil, open_err`；`save`/`find` 把具体错误向上传，便于真机定位。`merge` 维持原静默契约（仅判真/假） |
| ④ | `migrate()`/`ensure_schema()`/`set_user_version()` 失败契约不统一：迁移函数显式返回 false 未被视作失败，且 `user_version` 写入失败被静默吞掉 | ✅ `set_user_version` 返回 pcall 结果（写失败可感知）；`migrate` 对迁移函数显式返回 false 也视为失败、立即中止；`ensure_schema` 在 migrate 失败或 user_version 写入失败时一律返回 false，绝不返回「可用库」、绝不推进 user_version（防止下次打开跳过必要迁移）。暴露 `ThoughtDB.MIGRATIONS` 供测试注入 |

**测试**：新增 6 用例（原子 rename 失败立即中止 / 空错误文本 uncheckable 阻断 / 迁移返回 false→open 失败 / 迁移抛错→open 失败 / 无迁移路径 user_version 正常 / open_db 透传具体错误）。全量 **236 passed / 0 failed**（基线 230 + 6）。CI `quality / verify` 对 head `edf562f` **通过**（actions/runs/32647192802）。配套更新日志：`audit/10-db-integrity-changelog.html`（已同步至 fork `main` 提交 7f85198，不进本 PR diff）。请作者复核第8轮四项。
