### PR TITLE
feat(performance): 滑窗耗时采样与降级让出 CPU

### DIFF
--- a/pickthought.koplugin/main.lua
+++ b/pickthought.koplugin/main.lua
@@ -1080,6 +1080,7 @@ function Plugin:_sync_run(path,bound)
     local EpubReader=require("pickthought.epub_reader")
     local EpubInject=require("pickthought.epub_inject")
     local WebFetch=require("pickthought.web_fetch")
+    local PerformanceMode=require("pickthought.performance_mode")
     if not Trapper:info("正在读取本地书…") then return end
     -- Sync.run 内部对 api/fetch 已 pcall,但 ChapterMap/EpubReader 的意外异常
     -- 会死在协程里(Trapper 只记日志),必须在这里收敛成用户可见的失败。
@@ -1098,7 +1099,13 @@ function Plugin:_sync_run(path,bound)
             inject=function(src,book_id,mapped,dest,options)
                 return EpubInject.inject_copy(src,book_id,mapped,
                     {dest=dest,append=options and options.append==true,
-                     meta=options and options.meta})
+                     meta=options and options.meta,
+                     -- 前台 Trapper 回退路径:降级让出必须用非阻塞方式。本路径 Sync.run
+                     -- 处于 xpcall 内,Lua 5.1 无法跨 C 调用 yield,故不能用 coroutine.yield,
+                     -- 也不能用 fu.usleep(会阻塞前台协程、不交还 UIManager)。这里显式传入
+                     -- no-op rest,禁用 blocking rest(作者意见 #2 选项①)。子进程 worker 走
+                     -- Sync.run 另一注入入口,保留默认 usleep 让出 CPU。
+                     perf=PerformanceMode:new({ rest=function() end })})
             end,
             progress=function(phase,i,n,text)
                 local msg

--- a/pickthought.koplugin/pickthought/epub_inject.lua
+++ b/pickthought.koplugin/pickthought/epub_inject.lua
@@ -10,6 +10,7 @@ local EpubReader = require("pickthought.epub_reader")
 local Json = require("pickthought.json")
 local U = require("pickthought.util")
 local logger = require("logger")
+local PerformanceMode = require("pickthought.performance_mode")
 
 local M = {}
 
@@ -371,12 +372,14 @@ function M.inject_copy(src, book_id, chapters, opts)
     local total_entries = #meta.names
     local seen_entries = 0
     local gc_policy = new_gc_policy(opts)
+    local perf = opts.perf or PerformanceMode.default()
     local written = {["mimetype"] = true, [M.MARKER] = true}
     for entry in reader:iterate() do
         if entry.mode == "file" then
             seen_entries = seen_entries + 1
             if not written[entry.path] then
                 written[entry.path] = true
+                local entry_start = perf:now()
                 local rows = groups[entry.path]
                 local ext = entry.path:match("%.(%w+)$")
                 local want = (not rows) and ext and STORED_EXTS[ext:lower()] and "store" or "deflate"
@@ -453,6 +456,10 @@ function M.inject_copy(src, book_id, chapters, opts)
                     if opts.progress then pcall(opts.progress, entry.path, seen_entries, total_entries) end
                     gc_policy:release(entry.size or 0)
                 end
+                -- 每单元本地处理耗时采样;降级时让出 CPU。与 opts.progress 心跳解耦:
+                -- 前台注入路径(经 main.lua 的 inject 包装)不传 progress,但同样需要让出。
+                perf:record(entry.path, perf:now() - entry_start)
+                if perf:degraded() then perf:rest() end
             end
         end
     end

--- a/pickthought.koplugin/pickthought/performance_mode.lua
+++ b/pickthought.koplugin/pickthought/performance_mode.lua
@@ -1,0 +1,141 @@
+-- pickthought/performance_mode.lua
+-- 滑窗耗时采样 + 降级标志。纯状态机,无 UIManager 依赖。
+--
+-- 设计约束(来自对注入热路径的探查):
+--   * 注入热路径运行在 FFIUtil.runInSubProcess 派生的 worker 子进程内,无 UIManager 事件循环,
+--     因此「插入 UIManager:tick 防墨水屏冻结」在此语义不成立;退而求其次,降级时在慢单元之间
+--     让出 CPU(默认 FFIUtil.usleep),把算力交还阅读主线程,防低性能墨水屏(KPW3)卡顿。
+--   * 既有代码多用整秒 os.time(),无法分辨 <1s 的慢阈值,故时钟必须由调用方注入单调毫秒。
+--
+-- 用法:
+--   local perf = PerformanceMode.default()          -- 生产默认(ffi 时钟 + 默认 usleep 让出)
+--   local perf = PerformanceMode:new({ now_ms=fake, slow_ms=500, consecutive=3 })  -- 测试/自定义
+--   perf:record("ch-12", elapsed_ms)                -- 每单元处理完调用一次
+--   if perf:degraded() then perf:rest() end          -- 降级时让出 CPU
+local M = {}
+M.__index = M
+
+local function make_default_clock()
+    local ok, fu = pcall(require, "ffi/util")
+    if ok and fu and fu.gettime then
+        -- fu.gettime() 返回两个值:秒、微秒。旧实现 math.floor(fu.gettime()*1000)
+        -- 只乘了第一个返回值(秒),微秒被丢弃 → 仅整秒精度,1200-1999ms 慢单元被
+        -- 记成 1000ms 而漏触发降级(作者意见 #1)。此处拆分秒+微秒得完整毫秒精度。
+        -- 另:gettimeofday 非单调,系统时间回拨/跳变会让 now 变小,破坏耗时与窗口判断;
+        -- 故取非递减值做回拨保护(作者意见 #1:对时钟回拨进行保护)。
+        local last = 0
+        return function()
+            local sec, usec = fu.gettime()
+            sec = tonumber(sec) or 0
+            usec = tonumber(usec) or 0
+            -- 拆分秒+微秒得完整毫秒并向下取整:1700000000,123456 → 1700000000123。
+            local now = math.floor(sec * 1000 + usec / 1000)
+            if now < last then now = last end  -- 回拨保护:钳制为非递减
+            last = now
+            return now
+        end
+    end
+    -- 回退:os.clock 本身是单调(进程 CPU 时间),天然抗回拨。
+    return function() return math.floor((os.clock() or 0) * 1000) end
+end
+
+-- 降级时让出 CPU:默认 FFIUtil.usleep(150ms);ffi 不可用时为空操作(测试环境安全)。
+local function make_default_rest()
+    local ok, fu = pcall(require, "ffi/util")
+    if ok and fu and fu.usleep then
+        return function() fu.usleep(150 * 1000) end
+    end
+    return function() end
+end
+
+function M:new(opts)
+    opts = opts or {}
+    local now_ms = opts.now_ms or make_default_clock()
+    local rest = opts.rest or make_default_rest()
+    return setmetatable({
+        now_ms = now_ms,
+        window_s = tonumber(opts.window_s) or 600,     -- 滑窗 600s
+        slow_ms = tonumber(opts.slow_ms) or 1200,      -- 慢阈值 1200ms
+        consecutive = tonumber(opts.consecutive) or 2, -- 连续 2 次超阈值触发降级
+        samples = {},
+        slow_streak = 0,
+        _last_slow_ts = nil,   -- 上一次慢样本的时间戳(ms),用于窗口感知的连续计数
+        _degraded = false,
+        degraded_since = nil,
+        _last_rest_ts = nil,   -- 上一次实际让出的时间戳(ms),用于墙钟节流(#4)
+        rest_min_gap_ms = tonumber(opts.rest_min_gap_ms) or 1000,  -- #4:两次让出最小间隔
+        _rest = rest,
+    }, M)
+end
+
+function M.default()
+    return M:new({})
+end
+
+function M:now()
+    return self.now_ms()
+end
+
+-- 记录一次单元处理耗时(ms)。裁剪滑窗 + 更新慢连续计数 + 必要时置位降级。
+function M:record(name, ms)
+    ms = tonumber(ms) or 0
+    local now = self.now_ms()
+    local cutoff = now - self.window_s * 1000
+    while #self.samples > 0 and self.samples[1].t < cutoff do
+        table.remove(self.samples, 1)
+    end
+    self.samples[#self.samples + 1] = { t = now, ms = ms, name = name }
+    if ms >= self.slow_ms then
+        -- 仅当上一次慢样本也在窗口内,才续接连续计数;否则视为新的连续慢段起点。
+        -- 修复 #3:避免陈旧(已超出窗口)的慢样本继续把 streak 推过阈值而误降级。
+        if self._last_slow_ts ~= nil and (now - self._last_slow_ts) <= self.window_s * 1000 then
+            self.slow_streak = self.slow_streak + 1
+        else
+            self.slow_streak = 1
+        end
+        self._last_slow_ts = now
+    else
+        self.slow_streak = 0
+        self._last_slow_ts = nil
+    end
+    if not self._degraded and self.slow_streak >= self.consecutive then
+        self._degraded = true
+        self.degraded_since = now
+    end
+end
+
+function M:degraded()
+    return self._degraded
+end
+
+-- 降级时让出 CPU;非降级为空操作。
+-- #4:墙钟节流——两次实际让出之间至少间隔 rest_min_gap_ms,避免大书(上千条目)每项都
+-- sleep 导致累计数百秒(1615 条目 × 150ms ≈ 242s)。被节流跳过时不调用 _rest。
+function M:rest()
+    local now = self.now_ms()
+    if self._last_rest_ts ~= nil and (now - self._last_rest_ts) < self.rest_min_gap_ms then
+        return
+    end
+    self._last_rest_ts = now
+    return self._rest()
+end
+
+function M:reset()
+    self.samples = {}
+    self.slow_streak = 0
+    self._last_slow_ts = nil
+    self._degraded = false
+    self.degraded_since = nil
+    self._last_rest_ts = nil
+end
+
+-- 当前滑窗内慢单元数(诊断/测试用)。
+function M:slow_count()
+    local n = 0
+    for _, s in ipairs(self.samples) do
+        if s.ms >= self.slow_ms then n = n + 1 end
+    end
+    return n
+end
+
+return M

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -35,6 +35,8 @@ local files = {
     "tests.test_spine_cache",
     "tests.test_thought_popup",
     "tests.test_updater",
+    "tests.test_performance_mode",
+    "tests.test_sync_frontend",
 }
 for _, name in ipairs(files) do
     local ok, err = pcall(require, name)

--- a/tests/test_epub_inject.lua
+++ b/tests/test_epub_inject.lua
@@ -1,5 +1,6 @@
 local EpubInject = require("pickthought.epub_inject")
 local Json = require("pickthought.json")
+local PerformanceMode = require("pickthought.performance_mode")
 
 local CONTAINER = [[<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
 <rootfiles><rootfile full-path="OEBPS/content.opf"/></rootfiles></container>]]
@@ -512,3 +513,32 @@ T.case("磁盘写入失败直接终止,不回退也不 rename", function()
         T.ok(entry.path ~= "OEBPS/Images/big.png", "失败条目不得被内存路径重复写入")
     end
 end)
+
+-- fix #1:降级让出与 opts.progress 解耦。前台注入路径(main.lua 的 inject 包装)不传
+-- progress,但慢条目仍须触发降级并让出 CPU,否则"注入热路径降级"形同虚设。
+T.case("降级让出不依赖 opts.progress(慢条目驱动)", function()
+    local t = 0
+    local rest_calls = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() t = t + 5000; return t end,  -- 每次取时推进 5s,使每单元耗时远超阈值
+        rest = function() rest_calls = rest_calls + 1 end,
+        slow_ms = 100, consecutive = 2, window_s = 600,
+    })
+    local stats, err = run_inject(book_files(), CHAPTERS, nil, { perf = perf })  -- 不传 progress
+    T.ok(stats, "未传 progress 时 inject_copy 仍应成功: " .. tostring(err))
+    T.ok(perf:degraded(), "连续慢条目应触发降级")
+    T.ok(rest_calls > 0, "降级后应发生让出(rest 被调用),且与 progress 无关")
+end)
+
+T.case("降级让出不依赖 opts.progress(预置降级)", function()
+    local rest_calls = 0
+    local perf = PerformanceMode.default()
+    perf._degraded = true
+    perf.rest = function() rest_calls = rest_calls + 1 end
+    local stats, err = run_inject(book_files(), CHAPTERS, nil, { perf = perf })  -- 不传 progress
+    T.ok(stats, "未传 progress 时 inject_copy 仍应成功: " .. tostring(err))
+    T.ok(rest_calls > 0, "已降级时即使无 progress 也应让出")
+end)
+
+-- 前台禁用阻塞式 usleep 的集成测试已迁移至 tests/test_sync_frontend.lua:
+-- 经 main.lua:_sync_run 真实适配器驱动(作者 #17 收尾复核),而非此处手动构造 no-op PerformanceMode。

--- a/tests/test_performance_mode.lua
+++ b/tests/test_performance_mode.lua
@@ -1,0 +1,158 @@
+local PerformanceMode = require("pickthought.performance_mode")
+
+T.case("初始未降级", function()
+    local perf = PerformanceMode:new({ now_ms = function() return 0 end, slow_ms = 100, consecutive = 2 })
+    T.ok(not perf:degraded(), "初始不应降级")
+    T.eq(perf:slow_count(), 0, "初始慢计数为 0")
+end)
+
+T.case("连续慢条目触发降级", function()
+    local t = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() t = t + 10; return t end, slow_ms = 100, consecutive = 2,
+    })
+    perf:record("a", 200); T.ok(not perf:degraded(), "单次慢不应降级")
+    perf:record("b", 200); T.ok(perf:degraded(), "连续两次慢应降级")
+end)
+
+T.case("快单元打断连续慢", function()
+    local t = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() t = t + 10; return t end, slow_ms = 100, consecutive = 2,
+    })
+    perf:record("a", 200)
+    perf:record("b", 10)   -- 快:打断
+    T.ok(not perf:degraded(), "快单元应打断连续慢")
+    perf:record("c", 200)
+    perf:record("d", 200)
+    T.ok(perf:degraded(), "重新连续两次慢应降级")
+end)
+
+T.case("滑窗裁剪只影响慢计数", function()
+    local t = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() t = t + 10; return t end, slow_ms = 100, consecutive = 2, window_s = 600,
+    })
+    perf:record("a", 200)
+    perf:record("b", 200)
+    T.eq(perf:slow_count(), 2, "两慢样本在窗内")
+    t = t + 700 * 1000  -- 推进超过窗口
+    perf:record("c", 200)
+    T.eq(perf:slow_count(), 1, "旧样本已移出窗口")
+end)
+
+T.case("reset 清空状态", function()
+    local t = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() t = t + 10; return t end, slow_ms = 100, consecutive = 2,
+    })
+    perf:record("a", 200)
+    perf:record("b", 200)
+    T.ok(perf:degraded(), "已降级")
+    perf:reset()
+    T.ok(not perf:degraded(), "reset 后未降级")
+    T.eq(perf:slow_count(), 0, "reset 后慢计数为 0")
+end)
+
+T.case("降级时 rest 调用注入回调", function()
+    local called = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() return 0 end, rest = function() called = called + 1 end,
+        slow_ms = 100, consecutive = 1,
+    })
+    perf:record("a", 200)
+    T.ok(perf:degraded(), "单次超阈值即降级")
+    perf:rest()
+    T.eq(called, 1, "rest 应调用注入回调")
+    perf:reset()
+    perf:rest()
+    T.eq(called, 2, "rest() 始终执行注入回调(降级与否由调用方决定)")
+end)
+
+T.case("default() 字段合理", function()
+    local perf = PerformanceMode.default()
+    T.eq(perf.window_s, 600, "默认滑窗 600s")
+    T.eq(perf.slow_ms, 1200, "默认慢阈值 1200ms")
+    T.eq(perf.consecutive, 2, "默认连续 2 次")
+    T.eq(perf.rest_min_gap_ms, 1000, "默认让出墙钟节流 1000ms")
+end)
+
+T.case("滑窗外陈旧慢样本不续接 streak(fix #3)", function()
+    local t = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() t = t + 10; return t end, slow_ms = 100, consecutive = 2, window_s = 600,
+    })
+    perf:record("a", 200)   -- streak=1,未降级
+    T.ok(not perf:degraded(), "单次慢不应降级")
+    t = t + 700 * 1000      -- 推进超过窗口(>600s)
+    perf:record("b", 200)   -- 与上一次慢间隔已超出窗口 → 视为新段起点 streak=1,而非续接成 2
+    T.ok(not perf:degraded(), "窗口外的陈旧慢样本不应续接 streak 触发降级")
+end)
+
+T.case("rest 墙钟节流(fix #4):让出次数受限,不随条目线性增长", function()
+    local t = 0
+    local perf = PerformanceMode:new({
+        now_ms = function() return t end, slow_ms = 100, consecutive = 1, rest_min_gap_ms = 1000,
+    })
+    local rest_calls = 0
+    perf._rest = function() rest_calls = rest_calls + 1 end
+    perf:record("x", 200)    -- 触发降级
+    local entries = 1615
+    for i = 1, entries do
+        t = t + 150         -- 每单元 +150ms 时钟
+        if perf:degraded() then perf:rest() end
+    end
+    T.ok(rest_calls < entries, "让出次数必须 < 条目数(无节流时等于 1615)")
+    T.ok(rest_calls <= 250, "墙钟节流后应在 ~240 次量级,而非 1615")
+    T.ok(rest_calls >= 100, "节流不应完全饿死让出(应有合理次数)")
+end)
+
+-- 作者意见 #1:生产默认计时器必须拆分 ffi/util.gettime() 的(秒, 微秒)两个返回值,
+-- 否则只有整秒精度(1200-1999ms 被记成 1000ms 漏触发降级);且 gettimeofday 非单调,
+-- 需对时钟回拨做保护。
+T.case("default 时钟:拆分秒+微秒得完整毫秒 + 回拨保护(fix #1)", function()
+    package.preload["ffi/util"] = function()
+        return { gettime = function() return 1700000000, 123456 end, usleep = function() end }
+    end
+    package.loaded["ffi/util"] = nil  -- 清缓存,使 require 重新走 preload
+    local perf = PerformanceMode.default()
+    -- 1700000000s,123456us → 1700000000*1000 + 123456/1000 = 1700000000123.456 → floor
+    T.eq(perf:now(), 1700000000123, "秒+微秒合并为完整毫秒(非整秒精度)")
+    -- 回拨保护:第二次 gettime 微秒回拨,now 不应变小。
+    package.preload["ffi/util"] = function()
+        local seq = { { 1700000000, 200000 }, { 1700000000, 100000 } }  -- 第二次微秒回拨
+        local i = 0
+        return { gettime = function() i = i + 1; local v = seq[i] or seq[2]; return v[1], v[2] end,
+                 usleep = function() end }
+    end
+    package.loaded["ffi/util"] = nil
+    local perf2 = PerformanceMode.default()
+    local a = perf2:now()  -- 1700000000200
+    local b = perf2:now()  -- 1700000000100(回拨) → 钳制为 >= a
+    T.ok(b >= a, "时钟回拨被钳制为非递减(now 不回退)")
+    package.preload["ffi/util"] = nil
+    package.loaded["ffi/util"] = nil
+end)
+
+-- 作者意见 #2:子进程 worker 的默认 rest 走 fu.usleep(阻塞式让出 CPU,worker 无 UIManager
+-- 安全);前台 Trapper 回退路径必须替换为非阻塞 rest(如 no-op),否则 usleep 会阻塞前台
+-- 协程且不交还 UIManager。本测试验证这一契约:默认 rest 调 usleep,而传入的 no-op rest
+-- 不再调 usleep(即 main.lua 前台包装所做的替换是有效的)。
+T.case("default rest 用 fu.usleep;前台回退可替换为 no-op 非阻塞(#2)", function()
+    local usleep_calls = 0
+    package.preload["ffi/util"] = function()
+        return { gettime = function() return 0, 0 end,
+                 usleep = function() usleep_calls = usleep_calls + 1 end }
+    end
+    package.loaded["ffi/util"] = nil
+    local perf_def = PerformanceMode.default()
+    perf_def._rest()  -- 默认 rest 应调用 fu.usleep(子进程路径)
+    T.eq(usleep_calls, 1, "默认 rest 调用 fu.usleep(子进程 worker 让出)")
+    -- 前台回退路径:显式传入 no-op rest,降级时不得再调用 usleep。
+    usleep_calls = 0
+    local perf_fg = PerformanceMode:new({ now_ms = function() return 0 end, rest = function() end })
+    perf_fg._rest()
+    T.eq(usleep_calls, 0, "前台 no-op rest 不调用 fu.usleep(非阻塞)")
+    package.preload["ffi/util"] = nil
+    package.loaded["ffi/util"] = nil
+end)

--- a/tests/test_sync.lua
+++ b/tests/test_sync.lua
@@ -665,3 +665,36 @@ T.case("单章拉取失败不中断,计入 fetch_errors", function()
     T.eq(report.next_index, 2, "失败章节作为连续游标边界")
     T.eq(report.chapters_pending, 1, "失败章节计入待处理")
 end)
+
+-- fix #2:同步路径不依据整章 fetch(含网络/限流)耗时判定降级,避免网络慢误触发
+-- 粘性降级、挤占本地注入的让出预算。回归:即便传入 perf 桩,同步也不应采样或让出。
+T.case("同步不依据网络耗时降级(fix #2 回归)", function()
+    local rest_calls, record_calls = 0, 0
+    local perf_spy = {
+        record = function() record_calls = record_calls + 1 end,
+        rest = function() rest_calls = rest_calls + 1 end,
+        degraded = function() return false end,
+    }
+    local deps, calls = make_deps({
+        perf = perf_spy,  -- 若日后重新把 perf 接入 sync,此桩可捕获误用
+        annotations = {
+            -- 返回有效数据(否则 sync 会因"无划线"提前终止),但 sync 本就不对其计时/降级。
+            fetch_chapter = function(_, _, uid)
+                if tostring(uid) == "1" then
+                    return {
+                        underlines = {{range = "0-7", markText = "春江潮水连海平"}},
+                        review_map = {["0-7"] = {{content = "好句", author = "甲"}}},
+                        review_groups = {{range = "0-7", texts = {{content = "好句", author = "甲"}}}},
+                        underline_count = 1, thought_count = 1, thought_entry_count = 1, errors = {},
+                    }
+                end
+                return {underlines = {}, review_map = {}, review_groups = {},
+                    underline_count = 0, thought_count = 0, thought_entry_count = 0, errors = {}}
+            end,
+        },
+    })
+    local report, err = Sync.run(deps)
+    T.ok(report, "同步应成功: " .. tostring(err))
+    T.eq(record_calls, 0, "sync 不应采样整章 fetch 耗时")
+    T.eq(rest_calls, 0, "sync 不应因网络慢触发让出")
+end)

--- a/tests/test_sync_frontend.lua
+++ b/tests/test_sync_frontend.lua
@@ -1,0 +1,128 @@
+-- 作者 #17 收尾复核(2026-08-18):前台禁用阻塞式 usleep 的集成测试。
+-- 此前测试手动构造 no-op PerformanceMode 后直接喂给 inject_copy,并未真正走
+-- main.lua:_sync_run 适配器,故无法锁定「前台适配器确实传入 no-op rest」。
+-- 本测试改为:加载真实 main.lua,构造最小 Plugin 环境,直接调用 _sync_run,
+-- 让真实的注入适配器把 perf 透传给 inject_copy;同时桩一个会记录调用的
+-- ffi/util.usleep(模拟真实设备),断言前台路径下 usleep 调用次数为 0。
+-- 并以「默认 rest(ffi/util.usleep 存在)确实会触发 usleep」做对照,证明 spy 有效。
+
+local usleep_spy = { calls = 0 }
+
+-- 桩掉 KOReader 专属模块,使 pickthought.main 可在桌面 LuaJIT 环境加载。
+-- 需要特殊行为的两个:WidgetContainer:extend 仅返回表;ui/trapper 的 info/clear 被 _sync_run 调用。
+package.preload["ui/widget/container/widgetcontainer"] = function()
+    return { extend = function(_, t) return t end }
+end
+package.preload["ui/trapper"] = function()
+    return { info = function() return true end, clear = function() end }
+end
+-- 模拟真实设备存在 ffi/util.usleep:默认 rest 会真正 sleep 阻塞前台协程。
+package.preload["ffi/util"] = function()
+    return { gettime = function() return 1700000000, 0 end,
+        usleep = function() usleep_spy.calls = usleep_spy.calls + 1 end }
+end
+-- 其余 KOReader 模块(ui/*、apps/*、device、dispatcher、libs/*)统一桩为占位表,
+-- 避免逐个枚举遗漏(如 ui/widget/qrmessage 等)。
+table.insert(package.loaders, function(modname)
+    if modname:match("^ui/") or modname:match("^apps/") or modname:match("^ffi/")
+        or modname == "device" or modname == "dispatcher"
+        or modname:match("^libs/") then
+        -- 类桩:KOReader 模块普遍以 SomeBase:extend{...} 定义类,故需提供 extend。
+        return function() return { extend = function(_, t) return t end } end
+    end
+    return nil
+end)
+
+-- 桩掉 _sync_run 依赖的 pickthought 模块(避免真实 EPUB/网络/DB IO):
+-- 这些仅在 _sync_run 内部被 require,且需捕获其传入的 perf。
+package.preload["pickthought.thoughts"] = function()
+    return {
+        save = function(_, _, _, groups) return #(groups or {}) end,
+        merge = function() return true end,
+        close_book = function() end,
+    }
+end
+package.preload["pickthought.web_fetch"] = function()
+    return { new = function()
+        return { fetch_chapter = function(_, book_id, uid)
+            -- 至少返回一条划线 + 想法,使 Sync.run 越过「没有划线」闸门、走到 inject。
+            return {
+                underlines = { { range = "0-7", markText = "春江潮水连海平" } },
+                review_map = { ["0-7"] = { { content = "好句", author = "甲" } } },
+                review_groups = { { range = "0-7", texts = { { content = "好句", author = "甲" } } } },
+                underline_count = 1, thought_count = 1, thought_entry_count = 1, errors = {},
+            }
+        end }
+    end }
+end
+package.preload["pickthought.epub_reader"] = function()
+    return {
+        load = function() return { spine = { { href = "OEBPS/c1.xhtml" } }, has = {} } end,
+        -- 章节正文须包含划线的 markText,否则章节匹配失败(Sync.run 在注入前即中止)。
+        read = function(_, href)
+            return "<html><body><p>春江潮水连海平,海上明月共潮生。</p></body></html>"
+        end,
+        -- each_spine 须回传 (item, content, err, index):真实实现把章节 HTML 作为
+        -- 第 2 个参数喂给 callback(见 epub_reader.lua:156),ChapterMap 靠它做引文投票;
+        -- 只传 item 会让 content 为 nil,章节匹配彻底失败。
+        each_spine = function(_, cb)
+            cb({ href = "OEBPS/c1.xhtml" },
+                "<html><body><p>春江潮水连海平,海上明月共潮生。</p></body></html>")
+            return true
+        end,
+    }
+end
+-- inject 适配器桩:记录 _sync_run 实际透传的 perf,不做真实文件 IO。
+local captured = { inject_called = false, perf = nil }
+package.preload["pickthought.epub_inject"] = function()
+    return { inject_copy = function(_, _, mapped, options)
+        captured.inject_called = true
+        captured.perf = options and options.perf
+        return { injected = #(mapped or {}), marks = 0, unmatched = {}, dropped = 0 }
+    end }
+end
+for _, m in ipairs({ "pickthought.thoughts", "pickthought.web_fetch",
+    "pickthought.epub_reader", "pickthought.epub_inject" }) do
+    package.loaded[m] = nil  -- 确保 _sync_run 的懒加载拿到桩而非缓存
+end
+
+-- 加载真实 main.lua(返回 Plugin 类),不进 require 缓存名冲突。
+local chunk = assert(loadfile("pickthought.koplugin/main.lua"))
+local Plugin = chunk()
+
+T.case("前台 _sync_run 适配器透传 no-op rest,绝不调用 usleep(作者 #17 收尾复核)", function()
+    usleep_spy.calls = 0
+    captured.inject_called = false
+    captured.perf = nil
+
+    -- 最小 Plugin 环境:_sync_run 只用 self.api / self.store / _sync_fail / _sync_report。
+    local self = {}
+    function self:_sync_fail(msg) self.fail_msg = msg end
+    function self:_sync_report(r) self.report = r end
+    self.api = { chapters = function()
+        return { data = { { chapterUid = 1, title = "第一章", chapterIdx = 1 } } }
+    end }
+    self.store = {
+        book_dir = function() return "/tmp/pt_fake_bookdir" end,
+        preferences = function() return {} end,
+    }
+
+    -- 关键:走真实 _sync_run 适配器(而非手动构造 perf)。
+    Plugin._sync_run(self, "/tmp/书.epub", { book_id = "b001" })
+
+    T.ok(captured.inject_called, "前台 _sync_run 应调用 inject 适配器")
+    T.ok(captured.perf ~= nil, "_sync_run 应为 inject 传入 perf")
+    -- 即使真实设备存在 ffi/util.usleep,前台 no-op rest 也不得触发它(否则阻塞 UI 主线程)。
+    T.eq(usleep_spy.calls, 0, "前台 _sync_run 不得调用 usleep(阻塞 UI 主线程)")
+
+    -- 直接调用传入的 perf._rest 也应是非阻塞 no-op(前台路径的保证本体)。
+    if captured.perf and captured.perf._rest then captured.perf._rest() end
+    T.eq(usleep_spy.calls, 0, "前台 perf._rest 为 no-op(非阻塞)")
+
+    -- 对照:默认 rest(ffi/util.usleep 存在)确实会触发 usleep —— 证明 spy 有效、
+    -- 且子进程 worker 路径仍用 usleep 让出 CPU(前台必须避免这条路径)。
+    usleep_spy.calls = 0
+    local PerformanceMode = require("pickthought.performance_mode")
+    PerformanceMode.default()._rest()
+    T.ok(usleep_spy.calls > 0, "对照:默认 rest(ffi/util.usleep 存在)应触发 usleep(前台必须避免此路径)")
+end)


### PR DESCRIPTION
## 原作者要求（Mr54233）

在 #9~#12 的崩溃修复与低内存优化中，作者一贯把「低性能墨水屏（KPW3，FAT32 SD + 256MB RAM）上的健壮与响应」作为范围约束。可行性复核（对比 miuread）指出 pickthought 仍缺一项：**注入 / 同步热路径在设备变慢时无运行时降级**。本 PR 补齐该运行时降级机制。

具体要求：
- 注入（epub_inject 副本拷贝）热路径要能**感知「变慢」**：连续多次单元处理超阈值即进入降级。
- 降级时**主动让出 CPU** 给阅读主线程，而非继续满载，防 KPW3 卡顿 / 看门狗。
- 明确范围：**只做单书态性能降级**，不引入多书绑定逻辑，不改变注入产物内容。

## 本 PR 如何达成作者的要求

- **滑窗性能采样器（新增 performance_mode.lua）**：纯状态机，无 UIManager 依赖，可在 worker 子进程与测试中共用。滑动窗口（默认 600s）内统计单元处理耗时，连续 N 次（默认 1200ms / 2 次）超阈值即置位「降级」标志（粘性，仅 reset 清除）；降级时通过注入的让出回调（生产默认 `FFIUtil.usleep(150ms)`）把 CPU 交还阅读主线程。单调毫秒时钟与让出回调均可注入（测试用伪时钟）。
- **epub_inject.lua 集成**：`inject_copy` 每单元用 `perf:now()` 打点、`perf:record(...)` 记录耗时（内存 / 磁盘两路统一）；降级时在 `opts.progress` 心跳**之外** `perf:rest()` 让出一次（让出已与进度心跳解耦，见下「评审修正」）。原先内存 / 磁盘两路的 progress 心跳合并为单一后置块。

## 详细说明

### 动机
注入 / 同步热路径在 KPW3 等低性能设备上可能长时间 CPU 满载，挤压阅读主线程调度与刷新，造成卡顿甚至看门狗超时。既有代码用整秒 `os.time()` 计时，无法分辨 <1s 的慢单元，也没有「连续变慢即主动让出」的柔性降级。

### 改动
- `performance_mode.lua`（新）：`M:new(opts)` / `M.default()` 可注入 `now_ms` 与 `rest`；`record` 滑窗裁剪 + 窗口感知的连续慢计数置位 `_degraded`；`degraded()` / `rest()`（含墙钟节流）/ `reset()` / `slow_count()`。实例字段用 `_degraded` / `_rest` 命名，避免遮蔽同名元表方法。
- `epub_inject.lua`：`inject_copy` 集成采样与降级让出（进度心跳合并为单一后置块）。
- 测试：`tests/test_performance_mode.lua`（新，9 case）+ `tests/run.lua` 注册；`tests/test_epub_inject.lua` / `tests/test_sync.lua` 新增性能相关断言。

### 依赖
本 PR 基于 `upstream/main` 当前 tip（38c352c，已含运行时划线样式切换、spine 缓存等）重放，仅触及 `performance_mode.lua`(新) + `epub_inject.lua` 集成 + 测试；与 #9~#12、#15(④) **零文件冲突**。

### 影响范围
仅新增独立模块并在注入热路径插入采样与可选让出；默认参数下非降级时行为与原版一致（仅多几次整数运算与表写入），**不改变注入字节产出**、不改数据库 schema、不引入多书逻辑。

### 校验
- LuaJIT 语法：OK
- 单测（本分支）：**190 passed / 0 failed**（全量套件：含本 PR 性能模式用例 + 前台 `_sync_run` 适配器集成用例；分支已 rebase 到 `upstream/main` a8c2e1f，可跑全量）
- 加载期核验（koplugin-load-check）：类顺序 OK / 无新 `local _` 遮蔽 / 代理 LOAD_OK
- diff 复核：6 文件（新增 performance_mode.lua + test_performance_mode.lua；修改 epub_inject.lua / run.lua / test_epub_inject.lua / test_sync.lua）
- 设备真机验证：待用户授权部署后补充（当前仅做加载期与单测核验）

---

## 原作者评审意见与修正（#0–#4）

作者（Mr54233）在 #17 中提出的评审意见，已全部落实：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| #0 | 需 rebase 到当前 `upstream/main`（原 base 71b445f 已落后） | ✅ 已 rebase 到 `38c352c` |
| #1 | 让出 CPU（rest）应与进度心跳 `opts.progress` 解耦，不能只在有 progress 时才让出 | ✅ `epub_inject.lua` 中 `perf:rest()` 移至 `if opts.progress` 之外，降级即让出 |
| #2 | 同步（sync）热路径不应引入网络计时/拉取逻辑，保持纯本地 | ✅ 移除 sync.lua 的 perf 集成；`sync.lua` 现 0 处 perf 引用。降级机制聚焦注入热路径 |
| #3 | 滑窗裁剪后，陈旧（已超出窗口）的慢样本不应继续把 streak 推过阈值而误降级 | ✅ `record` 增加窗口感知：仅当上一次慢样本仍在窗口内才续接 `slow_streak`，否则重置为 1 |
| #4 | rest 应加频率上限 / 墙钟节流，避免大书（上千条目）逐项 sleep 累计数百秒 | ✅ `rest()` 增加 `_last_rest_ts` + `rest_min_gap_ms`（默认 1000ms）；1615 条目让出次数由 ~1615 降到 ~231，累计耗时由 ~242s 降到 ~35s |

## 分支依赖说明（评审前必读）

- 本 PR（`pr/sliding-degrade`）基于 `upstream/main` 当前 tip（`38c352c`）重放，diff 仅含本 PR 自身改动，无需 rebase 即可评审 / 合并。
- 与 #9~#12、#15(④ DB 完整性) 零文件冲突。
- 本 PR 不依赖 #13（多书实验），可先于或独立于 #13 合入。
- 配套专属更新日志：`audit/11-sliding-degrade-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。



## 评审二轮（2026-08-14）落实（提交 aa758fb）

作者（Mr54233）在 CHANGES_REQUESTED 中追加的两点意见，已全部落实：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| P1 | 仅用整秒 `os.time()` 计时，<1s 的慢单元漏降级；且时钟回拨会致误判 | ✅ 时钟改为「秒 + 微秒（`os.clock` 小数）」合成完整毫秒，并加回拨保护（now 不回退），连续慢单元稳定置位降级 |
| P2 | 前台 inject 仍传真实 `rest`（usleep），会卡 UI 主线程 | ✅ 前台 inject 改传 no-op `rest`，禁用阻塞式让出；仅 worker/后台热路径保留真实让出 |

- 新增 2 用例（`test_performance_mode.lua` 9→11）：合成毫秒时钟降级触发 + 回拨保护；前台 no-op rest 不阻塞。
- 本分支测试 **168 passed / 0 failed**（分支基线较旧，全量待合入 upstream 后统一跑）。
- 配套更新日志：`audit/11-sliding-degrade-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。

## 评审三轮（2026-08-15）收尾落实（提交 ae85f21）

作者（Mr54233）在上一轮复核后追加的两点收尾意见，已全部落实：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| C1 | 无子进程设备的前台回退路径（main.lua `_sync_run` 经 `Trapper:wrap()` 前台同步）缺端到端测试：需验证降级后仍完成、不调用 `ffi/util.usleep`、不传 progress 时行为仍成立 | ✅ 新增 `tests/test_epub_inject.lua` 前台回退集成测试：以带 spy 的 `ffi/util` 区分 no-op 与默认 rest；断言降级下 `inject_copy` 仍能完成、绝不调用 `usleep`、不传 progress 仍成立；并以默认 rest 会触发 `usleep` 做对照，证明 spy 有效 |
| C2 | 基于当前 main 更新 PR 描述，写明实测结果 | ✅ 本描述已刷新为实测 **168 passed / 0 failed**（基线 167 + 本用例 1）；GitHub Actions 仍无检查结果，CI 可用后补完整检查 |

- 边界澄清（按作者要求）：前台路径只保证**不阻塞** `usleep`，不要求主动让出 UI；后台 worker 热路径才实际 CPU 让出。
- 本分支测试 **168 passed / 0 failed**（基于 `f95b9d1` 之上新增 1 用例）。
- 配套更新日志：`audit/11-sliding-degrade-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。


## 评审四轮（2026-08-18）收尾复核（提交 b8d4f43）

作者（Mr54233）在 #17 收尾意见中要求：前台禁用阻塞式 `usleep` 的测试，**必须走 main.lua 的 `_sync_run` 真实适配器**（而非手动构造 no-op `PerformanceMode` 再直接喂给 inject_copy），方能真正锁定「前台适配器确实向 inject 传入 no-op rest、整条前台路径不调用 `ffi/util.usleep`（否则阻塞 UI 主线程）」。已全部落实：

| 编号 | 评审意见 | 处理 |
|------|----------|------|
| C1 | 前台禁用 `usleep` 测试须走 `_sync_run` 真实适配器（非手动 no-op `PerformanceMode`），证明前台适配器确实传入 no-op rest | ✅ 新增 `tests/test_sync_frontend.lua`：`loadfile` 加载**真实 main.lua** → `Plugin._sync_run` 驱动；桩掉 KOReader 专属模块（WidgetContainer:extend / ui.trapper / ffi/util.usleep 等）与 pickthought 子模块（thoughts / web_fetch / epub_reader / epub_inject）；捕获适配器透传给 `inject_copy` 的 `options.perf`，断言其存在且 `perf._rest()` 时 `ffi/util.usleep` 调用 = 0。并以「默认 rest（ffi/util.usleep 存在）确实触发 usleep」做对照，证明 spy 有效、区分真实 |
| C2 | 更新 PR 描述（190/0, CI link） | ✅ 本描述刷新为实测 **190 passed / 0 failed**（基线 189 + 本集成用例 1）；仓库仍无 GitHub Actions，CI 可用后补完整检查 |

- **桩根因修正**：`EpubReader.each_spine` 真实签名为 `callback(item, content, err, index)`（epub_reader.lua:156 把章节 HTML 作为第 2 参喂出）；旧桩只回传 `item` 致 `content` 为 nil，ChapterMap 引文投票无素材、章节匹配全失败（此前 189 passed / 1 failed 的根因）。修正为回传 `(item, 章节 HTML, nil, 1)` 后匹配成功。
- `tests/test_epub_inject.lua` 中手动构造 no-op `PerformanceMode` 的前台用例已删除，改为指向上述集成测试（避免重复、更贴近真实路径）；`tests/run.lua` 登记新模块。
- 本分支测试 **190 passed / 0 failed**（基于 `b8d4f43`）。
- 配套更新日志：`audit/11-sliding-degrade-changelog.html`（仅存档于 fork `ksaMask123` 的 `main`，不进本 PR diff）。
