### PR TITLE
perf(thoughts): 限制 SQLite 句柄并在关书时释放

### DIFF
--- a/pickthought.koplugin/main.lua
+++ b/pickthought.koplugin/main.lua
@@ -1193,6 +1193,11 @@ function Plugin:onReaderReady()
 end
 
 function Plugin:onCloseDocument()
+    local path = self:current_doc_path()
+    local binding = path and Binding.get(self.store, path)
+    if binding and binding.book_id then
+        Thoughts.close_book(self.store, binding.book_id)
+    end
     self:_teardown_thought_tap()
 end
 

--- a/pickthought.koplugin/pickthought/thoughts.lua
+++ b/pickthought.koplugin/pickthought/thoughts.lua
@@ -13,8 +13,28 @@ local lfs = require("libs/libkoreader-lfs")
 local Thoughts = {}
 
 -- per-book SQLite 句柄缓存:点击锚点时避免反复 open/close。
+-- KPW3 红线:句柄不得无上限累积——纯阅读期跨多本注入书点锚点会 slowly 涨内存
+-- (每个句柄连带 SQLite + WAL 文件)。加 LRU 上限,超出关最久未用,释放文件句柄。
 local db_cache = {}
+local db_cache_order = {}   -- LRU 顺序:表头最久未用,表尾最近使用
+local DB_CACHE_MAX = 4
 local migrated = {}  -- book_dir → 已检查旧 JSON 迁移(进程内不重复扫)
+
+local function db_cache_touch(book_dir)
+    for i, v in ipairs(db_cache_order) do
+        if v == book_dir then table.remove(db_cache_order, i); break end
+    end
+    db_cache_order[#db_cache_order + 1] = book_dir
+end
+
+local function db_cache_evict()
+    while #db_cache_order > DB_CACHE_MAX do
+        local old = table.remove(db_cache_order, 1)
+        local db = db_cache[old]
+        if db then pcall(ThoughtDB.close, db) end
+        db_cache[old] = nil
+    end
+end
 
 local function hex_encode(value)
     return (tostring(value or ""):gsub(".", function(ch)
@@ -39,10 +59,6 @@ end
 
 function Thoughts.href(book_id, chapter_uid, range)
     return "#" .. Thoughts.anchor(book_id, chapter_uid, range)
-end
-
-function Thoughts.mark_class(range)
-    return "pickthought-mark-" .. hex_encode(range)
 end
 
 function Thoughts.parse_href(href)
@@ -94,10 +110,15 @@ end
 local function open_db(store, book_id)
     local book_dir = store:book_dir(book_id)
     local db = db_cache[book_dir]
-    if db then return db end
+    if db then
+        db_cache_touch(book_dir)
+        return db
+    end
     db = ThoughtDB.open(book_dir)
     if not db then return nil end
     db_cache[book_dir] = db
+    db_cache_touch(book_dir)
+    db_cache_evict()
     if not migrated[book_dir] then
         migrated[book_dir] = true
         local ok_mig = pcall(migrate_legacy, book_id, book_dir, db)
@@ -252,9 +273,24 @@ function Thoughts.popup_text(group)
 end
 
 function Thoughts.clear_memory_cache()
-    for _, db in pairs(db_cache) do ThoughtDB.close(db) end
+    for _, db in pairs(db_cache) do pcall(ThoughtDB.close, db) end
     db_cache = {}
+    db_cache_order = {}
     -- migrated 不清:进程内已迁移的 book 不重复扫(目录已空,下次也跳过)。
+end
+
+-- 关闭单本书句柄(阅读端关闭文档时调用),释放 SQLite + WAL 文件。
+-- 之后若再点该书的锚点,open_db 会重新打开,无害。
+function Thoughts.close_book(store, book_id)
+    local book_dir = store:book_dir(book_id)
+    local db = db_cache[book_dir]
+    if db then
+        pcall(ThoughtDB.close, db)
+        db_cache[book_dir] = nil
+        for i, v in ipairs(db_cache_order) do
+            if v == book_dir then table.remove(db_cache_order, i); break end
+        end
+    end
 end
 
 return Thoughts

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -29,6 +29,7 @@ local files = {
     "tests.test_web_fetch", "tests.test_power_inhibit", "tests.test_sync_task",
     "tests.test_thought_db", "tests.test_thoughts",
     "tests.test_annotation_compat",
+    "tests.test_thoughts_lru",
 }
 for _, name in ipairs(files) do
     local ok, err = pcall(require, name)

--- a/tests/test_thoughts_lru.lua
+++ b/tests/test_thoughts_lru.lua
@@ -1,0 +1,84 @@
+-- SQLite 连接 LRU 淘汰测试。
+-- 思路:对真实 pickthought.thought_db 的 open/close 做 spy,
+-- 记录每次 open 的目录与被淘汰(evict)/close_book 关闭的目录,从而断言 LRU 真实生效。
+-- 关键:不替换模块、不返回代理句柄——open/close 仍走真实实现并返回真实句柄,
+-- 避免干扰 Thoughts.save 的真实写入路径(早先的代理包装会让 save 静默失败)。
+local real_db = require("pickthought.thought_db")
+local SQ3 = require("lua-ljsqlite3/init")
+
+-- 句柄 → 目录 反查表(弱键,避免句柄泄漏)。
+local handle_dir = setmetatable({}, { __mode = "k" })
+local opened, closed = {}, {}
+
+local orig_open = real_db.open
+local orig_close = real_db.close
+real_db.open = function(book_dir)
+    opened[#opened + 1] = book_dir
+    local db = orig_open(book_dir)
+    if db then handle_dir[db] = book_dir end
+    return db
+end
+real_db.close = function(db)
+    if db and handle_dir[db] then closed[handle_dir[db]] = true end
+    return orig_close(db)
+end
+
+-- 确保 thoughts 重新捕获(已 spy 的)同一 thought_db 表。
+package.loaded["pickthought.thoughts"] = nil
+local Thoughts = require("pickthought.thoughts")
+
+local function store_with(dir)
+    return { book_dir = function(_, _) return dir end }
+end
+
+local function reset_spies()
+    for k in pairs(opened) do opened[k] = nil end
+    for k in pairs(closed) do closed[k] = nil end
+end
+
+T.case("LRU: 打开超过上限会淘汰最久未用的句柄", function()
+    SQ3._reset()
+    reset_spies()
+    local dirs = {}
+    for i = 1, 6 do dirs[i] = "/t/lru/b" .. i end
+    -- 每本各存一条,save 内部会 open_db;DB_CACHE_MAX=4,开第5本淘汰 b1、开第6本淘汰 b2
+    for i = 1, 6 do
+        Thoughts.save(store_with(dirs[i]), "b" .. i, "1", {
+            { range = "0-7", texts = { { content = "想法" .. i, author = "x", likes = 0, review_id = "" } } },
+        })
+    end
+    T.ok(closed[dirs[1]], "最旧句柄 b1 被淘汰关闭")
+    T.ok(closed[dirs[2]], "次旧句柄 b2 被淘汰关闭")
+    T.ok(not closed[dirs[6]], "最新句柄 b6 未被淘汰")
+    T.ok(not closed[dirs[5]], "较新句柄 b5 未被淘汰")
+end)
+
+T.case("close_book 释放单本句柄后可重新打开且不丢数据", function()
+    SQ3._reset()
+    reset_spies()
+    local store = store_with("/t/closebook")
+    Thoughts.save(store, "cb", "1", {
+        { range = "0-7", texts = { { content = "x", author = "甲", likes = 0, review_id = "" } } },
+    })
+    Thoughts.close_book(store, "cb")
+    T.ok(closed["/t/closebook"], "close_book 触发了句柄 close")
+    local g = Thoughts.find(store, "cb", "1", "0-7")
+    T.ok(g and #g.texts == 1, "close_book 后重新打开仍可读取")
+    T.eq(g.texts[1].content, "x", "内容未丢失")
+end)
+
+T.case("LRU 压力下多本数据均可检索(淘汰不丢数据)", function()
+    SQ3._reset()
+    reset_spies()
+    local N = 12
+    for i = 1, N do
+        Thoughts.save(store_with("/t/stress/" .. i), "s" .. i, "1", {
+            { range = "0-7", texts = { { content = "d" .. i, author = "乙", likes = 0, review_id = "" } } },
+        })
+    end
+    -- 淘汰只关闭句柄、不删数据;重新打开(新句柄)应仍能读到。
+    for i = 1, N do
+        local g = Thoughts.find(store_with("/t/stress/" .. i), "s" .. i, "1", "0-7")
+        T.ok(g and #g.texts == 1, "书 s" .. i .. " 数据可检索")
+    end
+end)


### PR DESCRIPTION
基于最新 main 重放 PR #11。\n\n包含：\n- per-book SQLite 句柄 LRU 上限；\n- 关闭文档时释放当前书句柄；\n- 保留全量缓存清理；\n- 移除已无调用方的唯一标记 class 生成函数；\n- 补充 LRU、close_book 和压力测试。\n\n原 PR #11 与主线冲突，本 PR 是解决冲突后的可合并版本。桌面测试：140 passed / 0 failed。