### PR TITLE
perf(sync): 移植上游章节标题索引并修复全命中误报取消

### DIFF
--- a/pickthought.koplugin/pickthought/chapter_map.lua
+++ b/pickthought.koplugin/pickthought/chapter_map.lua
@@ -13,13 +13,18 @@ local ChapterMap = {}
 -- 匹配算法版本:任何影响匹配结果的改动(引文窗口、投票规则、目录页判定、
 -- 归一化规则)都必须 +1。映射缓存把它写进指纹,算法一改缓存整体作废——
 -- 否则旧算法缓存下来的「匹配失败」会永久生效,改进永远轮不到那些章节。
-ChapterMap.ALGO_VERSION = 8
+-- 9:迁移上游 weread PR #150 的标题键改进(宽松标题键/更新后缀关键词扩展/
+-- 英文 Chapter 前缀剥离/目标顺序守卫),标题匹配行为变化,旧缓存整体作废。
+ChapterMap.ALGO_VERSION = 9
 
 -- 标题钥匙:剥掉「第X章/节/回…」编号前缀。微信与本地书的章号体系
 -- 经常不一致(实测:微信「第六章 姑娘请自重」= 本地「第二百八十四章
 -- 姑娘请自重」),整标题匹配必死;章名本体才是稳定标识。
 -- 剥完不足 6 字节(如「上」「下」)退回全标题。
 local CHAPTER_ENDINGS = {"章", "节", "回", "卷", "部", "集", "篇"}
+-- 更新/求票类括号后缀关键词(对齐上游 weread PR #150):求票/订阅/收藏/打赏等
+-- 网文标题尾巴必须剥掉,精确键才能和干净章名对上。
+local UPDATE_SUFFIX_KEYWORDS = {"更", "求", "订", "阅", "票", "藏", "赏"}
 local CHAPTER_NUMBER_TOKENS = {
     "零", "〇", "一", "二", "三", "四", "五", "六", "七", "八", "九",
     "十", "百", "千", "万", "两",
@@ -27,10 +32,19 @@ local CHAPTER_NUMBER_TOKENS = {
 
 local function is_chapter_number(value)
     local number = tostring(value or ""):gsub("%d", "")
+    -- 罗马数字(对齐上游 is_outline_number):Chapter XIII / 第XII卷 都要认。
+    number = number:gsub("[IVXLCDMivxlcdm]", "")
     for _, token in ipairs(CHAPTER_NUMBER_TOKENS) do
         number = number:gsub(token, "")
     end
     return number == ""
+end
+
+local function has_update_keyword(text)
+    for _, keyword in ipairs(UPDATE_SUFFIX_KEYWORDS) do
+        if text:find(keyword, 1, true) then return true end
+    end
+    return false
 end
 
 local function strip_chapter_number(value)
@@ -64,7 +78,7 @@ local function strip_update_suffix(value)
         local close_at = #current - #closing + 1
         if last_open and close_at > last_open
             and current:sub(close_at, close_at + #closing - 1) == closing
-            and current:sub(last_open + #opening, close_at - 1):find("更", 1, true) then
+            and has_update_keyword(current:sub(last_open + #opening, close_at - 1)) then
             return current:sub(1, last_open - 1)
         end
         return current
@@ -78,11 +92,55 @@ local function strip_update_suffix(value)
     return text
 end
 
+-- 英文译作的「Chapter 12:」「CHAPTER XIII -」前缀(对齐上游 PR #150):
+-- 阿拉伯数字与罗马数字混排,后随冒号/点/横线等分隔符一并剥除。
+-- 注意 normalize 已去全部空白,%s* 只是双保险。
+local function strip_english_chapter_prefix(value)
+    return (value:gsub(
+        "^%s*[Cc][Hh][Aa][Pp][Tt][Ee][Rr]%s*[%divxlcdmIVXLCDM%d]+[%s:%.%-]*", ""))
+end
+
 function ChapterMap.title_key(title)
     local t = strip_update_suffix(ChapterMap.normalize(title))
     local stripped = strip_chapter_number(t)
+    if #stripped >= 6 then
+        t = stripped
+    end
+    -- 英文前缀剥离放在末位并套同一守卫:剥完过短(如「Chapter 1 上」)则不剥。
+    stripped = strip_english_chapter_prefix(t)
     if #stripped >= 6 then return stripped end
     return t
+end
+
+-- 宽松标题键(对齐上游 relaxed_chapter_title):剥「二、」「（二）」「二.」
+-- 这类卷内序号前缀,只留标题本体。出版体 EPUB 的标题常带本地卷内编号,而
+-- 微信章名没有,精确键永远对不上。守卫:序号必须是纯数字/中文数字/罗马数字,
+-- 序号后必须有分隔符,本体 ≥6 字节(2 个汉字,防「上/下」类高频短名错配);
+-- 任一不满足就退回 title_key 原结果。
+local function outline_split(base)
+    local number, rest = base:match("^%((.-)%)[%s,:%.%-]*(.+)$")
+    if not number then
+        number, rest = base:match("^([^,%s:%.%-%)]+)[,%s:%.%-%)]+(.+)$")
+    end
+    if not number then
+        -- 中文顿号「、」(U+3001):normalize 不折叠,不能进字节类(会误配
+        -- 其他 CJK 首字节),单独按「纯序号 + 顿号」处理;序号限 24 字节,
+        -- 防正文里迟到的顿号把整句当前缀。
+        local dot = base:find("\227\128\129", 1, true)
+        if dot and dot <= 25 then
+            number, rest = base:sub(1, dot - 1), base:sub(dot + 3)
+        end
+    end
+    if number and number ~= "" and rest and is_chapter_number(number) then
+        rest = rest:gsub("^%s+", ""):gsub("%s+$", "")
+        if #rest >= 6 then return rest end
+    end
+    return nil
+end
+
+function ChapterMap.relaxed_title_key(title)
+    local base = ChapterMap.title_key(title)
+    return outline_split(base) or base
 end
 
 local ENTITIES = {
@@ -212,6 +270,7 @@ local function heading_blocks(html, normalized)
                 blocks[#blocks + 1] = {
                     start = start, title = heading,
                     key = ChapterMap.title_key(heading),
+                    relaxed = ChapterMap.relaxed_title_key(heading),
                 }
             end
         end
@@ -253,10 +312,26 @@ local function build_with_scanner(spine, chapters, scan, options)
     local toc_threshold = math.max(2, math.ceil(#all_titles * 0.5))
 
     local title_index = {}   -- [title_key] = {chapter indexes}
+    local relaxed_keys, remote_relaxed_counts = {}, {}
     for ci, title in ipairs(titles) do
         if title then
             title_index[title] = title_index[title] or {}
             title_index[title][#title_index[title] + 1] = ci
+            -- 宽松键(上游 relaxed_chapter_title):剥卷内序号只留本体。
+            -- 远程无编号章名也注册(宽松键==精确键时的恒等身份),这样本地
+            -- 「二、标题」式编号标题剥号后才能找到它;只有远程侧唯一的宽松键
+            -- 才允许参与匹配——重复短名两侧都不唯一时,宽松配对必错。
+            local relaxed = ChapterMap.relaxed_title_key(chapters[ci].title)
+            if #relaxed >= 6 then
+                relaxed_keys[ci] = relaxed
+                remote_relaxed_counts[relaxed] = (remote_relaxed_counts[relaxed] or 0) + 1
+            end
+        end
+    end
+    local relaxed_index = {}
+    for ci, relaxed in pairs(relaxed_keys) do
+        if remote_relaxed_counts[relaxed] == 1 then
+            relaxed_index[relaxed] = ci
         end
     end
 
@@ -271,7 +346,7 @@ local function build_with_scanner(spine, chapters, scan, options)
     local metrics = {
         primary_files = 0, bounded_files = 0, bounded_chapters = 0,
         fallback_files = 0, fallback_chapters = 0, quote_checks = 0,
-        checkpoints = 0,
+        checkpoints = 0, relaxed_hits = 0, order_inversions = 0,
     }
 
     local function thought_count_of(chapter)
@@ -380,6 +455,19 @@ local function build_with_scanner(spine, chapters, scan, options)
                             start = block.start, ["end"] = block["end"],
                         }
                     end
+                elseif block.relaxed and relaxed_index[block.relaxed] then
+                    -- 宽松键 tier(两侧唯一才建索引):精确键失配但本体相同,
+                    -- 救回「本地卷内编号 / 微信无编号」的章节。
+                    local ci = relaxed_index[block.relaxed]
+                    if not distinct_titles[block.relaxed] then
+                        distinct_titles[block.relaxed] = true
+                        distinct_count = distinct_count + 1
+                    end
+                    metrics.relaxed_hits = metrics.relaxed_hits + 1
+                    block_matches[ci] = block_matches[ci] or {}
+                    block_matches[ci][#block_matches[ci] + 1] = {
+                        start = block.start, ["end"] = block["end"],
+                    }
                 else
                     -- 卷首说明可能把目标章名包在更长标题里(例如“第一卷...惊蛰...卷首”)。
                     -- 只在 h 标签块内做子串匹配,不会退化为每个正文文件扫描所有标题。
@@ -526,7 +614,9 @@ local function build_with_scanner(spine, chapters, scan, options)
         "bounded_chapters=", tostring(metrics.bounded_chapters),
         "fallback_files=", tostring(metrics.fallback_files),
         "fallback_chapters=", tostring(fallback_count),
-        "quote_checks=", tostring(metrics.quote_checks))
+        "quote_checks=", tostring(metrics.quote_checks),
+        "relaxed_hits=", tostring(metrics.relaxed_hits),
+        "order_inversions=", tostring(metrics.order_inversions))
     local function by_spine(a, b)
         return (tonumber(a.spine_index) or 0) < (tonumber(b.spine_index) or 0)
     end
@@ -539,6 +629,12 @@ local function build_with_scanner(spine, chapters, scan, options)
     -- 引文对齐的划线,禁用数字兜底,防止错位与跨文件重复。
     local MAX_TARGETS = 4
     local mapped, unmatched = {}, {}
+    -- 顺序单调守卫(上游 #150 在目录映射强制 candidate > previous 的撷思适配):
+    -- 每章定案锚点 = 其全部目标的最小 spine 序;后一章锚点小于前一章视为
+    -- 「序倒挂」(目录页/卷首重复文本把投票带偏的信号),该章强制 quote_only
+    -- 禁数字兜底并计数,不删除目标——引文确实对齐的内容不能因守卫丢失。
+    -- 锚点按 max 传递,兼容「微信合并章横跨多文件」的合法非递减场景。
+    local previous_anchor = nil
     for ci, ch in ipairs(chapters) do
         local underlines = ch.underlines or {}
         if #underlines == 0 then
@@ -573,6 +669,30 @@ local function build_with_scanner(spine, chapters, scan, options)
                 -- 只有「投票强证据 + 单目标」保留数字兜底(同版书受益);
                 -- 其余场景数字偏移不可信,一律 quote_only。
                 local quote_only = not vote_single or nil
+                -- R4 顺序守卫:锚点 = 本章全部目标的最小 spine 序。
+                local anchor
+                local target_seen = {}
+                for _, href in ipairs(targets) do target_seen[href] = true end
+                for _, entry in ipairs(scores[ci] or {}) do
+                    if target_seen[entry.href] then
+                        local idx = tonumber(entry.spine_index) or 0
+                        if not anchor or idx < anchor then anchor = idx end
+                    end
+                end
+                for _, hit in ipairs(title_hits[ci] or {}) do
+                    if target_seen[hit.href] then
+                        local idx = tonumber(hit.spine_index) or 0
+                        if not anchor or idx < anchor then anchor = idx end
+                    end
+                end
+                if anchor and previous_anchor and anchor < previous_anchor then
+                    quote_only = true
+                    metrics.order_inversions = metrics.order_inversions + 1
+                end
+                if anchor then
+                    previous_anchor = previous_anchor and
+                        math.max(previous_anchor, anchor) or anchor
+                end
                 for _, href in ipairs(targets) do
                     mapped[#mapped + 1] = {
                         chapter_uid = tostring(ch.uid or ""), href = href,

--- a/pickthought.koplugin/pickthought/epub_reader.lua
+++ b/pickthought.koplugin/pickthought/epub_reader.lua
@@ -145,6 +145,7 @@ function E.each_spine(meta, callback, archiver)
     end
     local seen = {}
     local cancelled = false
+    local all_matched = false
     local ok, scan_err = xpcall(function()
         for entry in reader:iterate() do
             local rows = not seen[entry.path] and wanted[entry.path] or nil
@@ -154,30 +155,38 @@ function E.each_spine(meta, callback, archiver)
                 local read_err = content == nil and (reader.err or
                     ("无法读取 EPUB 条目:" .. tostring(entry.path))) or nil
                 for _, row in ipairs(rows) do
-                    if callback(row.item, content, read_err, row.index) == false then
-                        cancelled = true
+                    local stop, reason = callback(row.item, content, read_err, row.index)
+                    if stop == false then
+                        -- callback 的第二个返回值是语义标记:"all_matched" 是
+                        -- 全部命中的成功信号,不是取消;丢了它,上游式提前退出
+                        -- 会被当成取消,把一次完美同步报成失败。
+                        cancelled = reason ~= "all_matched"
+                        all_matched = not cancelled
                         break
                     end
                 end
-                if cancelled then break end
+                if cancelled or all_matched then break end
             end
         end
-        if cancelled then return end
+        if cancelled or all_matched then return end
         for href, rows in pairs(wanted) do
             if not seen[href] then
                 for _, row in ipairs(rows) do
-                    if callback(row.item, nil, "EPUB 中缺少 spine 条目:" .. tostring(href), row.index) == false then
-                        cancelled = true
+                    local stop, reason = callback(row.item, nil, "EPUB 中缺少 spine 条目:" .. tostring(href), row.index)
+                    if stop == false then
+                        cancelled = reason ~= "all_matched"
+                        all_matched = not cancelled
                         break
                     end
                 end
-                if cancelled then break end
+                if cancelled or all_matched then break end
             end
         end
     end, debug.traceback)
     reader:close()
     if not ok then error(scan_err) end
     if cancelled then return false, "已取消" end
+    if all_matched then return false, "all_matched" end
     return true
 end
 

--- a/pickthought.koplugin/pickthought/sync.lua
+++ b/pickthought.koplugin/pickthought/sync.lua
@@ -768,8 +768,10 @@ function Sync.run(deps)
                 -- 暖模式:直接从缓存流式喂,完全不碰 EPUB。
                 for index, item in ipairs(m.spine or {}) do
                     local html = spine_cache:get(item.href)
-                    if callback(item, html, html == nil and "缓存缺失" or nil, index) == false then
-                        return false, "已取消"
+                    local stop, reason = callback(item, html, html == nil and "缓存缺失" or nil, index)
+                    if stop == false then
+                        -- reason 可能是 "all_matched"(全部命中的成功信号),必须透传。
+                        return false, reason or "已取消"
                     end
                 end
                 return true
@@ -783,8 +785,9 @@ function Sync.run(deps)
             end
             -- 无真实 read_spine:走 read_text 路径(仍经缓存)。
             for index, item in ipairs(m.spine or {}) do
-                if callback(item, cached_read_text(m, item.href), nil, index) == false then
-                    return false, "已取消"
+                local stop, reason = callback(item, cached_read_text(m, item.href), nil, index)
+                if stop == false then
+                    return false, reason or "已取消"
                 end
             end
             return true
@@ -794,8 +797,9 @@ function Sync.run(deps)
             return real_read_spine(m, callback)
         end
         for index, item in ipairs(m.spine or {}) do
-            if callback(item, real_read_text and real_read_text(m, item.href), nil, index) == false then
-                return false, "已取消"
+            local stop, reason = callback(item, real_read_text and real_read_text(m, item.href), nil, index)
+            if stop == false then
+                return false, reason or "已取消"
             end
         end
         return true

--- a/pickthought.koplugin/pickthought/sync_task.lua
+++ b/pickthought.koplugin/pickthought/sync_task.lua
@@ -790,8 +790,17 @@ function SyncTask:start(task, on_progress, on_done)
             local ok, encoded = pcall(JsonChild.encode, state)
             if ok then UChild.atomic_write(progress_path, encoded, true) end
         end
+        local debug_cancel_seen = false
         local function cancelled()
-            return UChild.file_exists(cancel_path)
+            local hit = UChild.file_exists(cancel_path)
+            if hit and not debug_cancel_seen then
+                debug_cancel_seen = true
+                logger.warn("[撷思][SyncTask][Diag] cancel file detected",
+                    "path=", tostring(cancel_path),
+                    "size=", tostring(UChild.file_size(cancel_path) or "n/a"),
+                    "os_time=", tostring(os.time()))
+            end
+            return hit
         end
 
         local function persist_failure_state(status, reason)

--- a/tests/test_chapter_map.lua
+++ b/tests/test_chapter_map.lua
@@ -334,3 +334,151 @@ T.case("章节映射检查点取消会停止扫描", function()
     T.ok(not ok and tostring(err):find("已取消", 1, true), "检查点取消向上传播")
     T.ok(calls > 0, "触发了检查点")
 end)
+
+-- ===== 以下为章节标题索引迁移(上游 PR #150 对齐)新增用例 =====
+
+T.case("更新后缀关键词扩展剥除(A1)", function()
+    -- R2:关键词集 {更,求,订,阅,票,藏,赏}。注意 title_key 本身还会剥
+    -- 「第三卷」编号(既有行为),最终键只剩章名本体。
+    T.eq(ChapterMap.title_key("第三卷 风雪夜归（求票）"), "风雪夜归", "求票括号剥除")
+    T.eq(ChapterMap.title_key("风雪夜归（订阅正文）"), "风雪夜归", "订阅括号剥除")
+    T.eq(ChapterMap.title_key("风雪夜归(收藏)"), "风雪夜归", "半角收藏括号剥除")
+    T.eq(ChapterMap.title_key("风雪夜归（求收藏打赏）"), "风雪夜归", "多关键词括号剥除")
+    T.eq(ChapterMap.title_key("风雪夜归（改）"), "风雪夜归(改)", "非关键词括号保留(全角折半角)")
+    T.eq(ChapterMap.title_key("风雪夜归（黄昏）"), "风雪夜归(黄昏)", "黄昏非关键词保留")
+end)
+
+T.case("英文 Chapter 前缀剥离(A2)", function()
+    -- R3:Chapter + 阿拉伯/罗马数字 + 分隔符
+    T.eq(ChapterMap.title_key("Chapter 12: 风雪夜归人"), "风雪夜归人", "阿拉伯数字英文前缀")
+    T.eq(ChapterMap.title_key("CHAPTER XIII - 天涯客"), "天涯客", "罗马数字大写前缀")
+    T.eq(ChapterMap.title_key("chapter 3.风起"), "风起", "小写前缀加点分隔")
+    T.eq(ChapterMap.title_key("Chapter 1 上"), "Chapter1上", "剥后过短保留原键")
+    T.eq(ChapterMap.title_key("风雪Chapters"), "风雪Chapters", "非前缀位置不动")
+end)
+
+T.case("宽松标题键提取正反例(A3)", function()
+    -- R1:序号 + 分隔符 + 本体(≥6 字节);任一不满足退回 title_key
+    T.eq(ChapterMap.relaxed_title_key("二、姑娘请自重"), "姑娘请自重", "顿号序号剥离")
+    T.eq(ChapterMap.relaxed_title_key("（二）风雪夜归"), "风雪夜归", "全角括号序号剥离")
+    T.eq(ChapterMap.relaxed_title_key("2. 风雪夜归"), "风雪夜归", "阿拉伯数字加点剥离")
+    T.eq(ChapterMap.relaxed_title_key("XII、天涯客"), "天涯客", "罗马数字序号剥离")
+    T.eq(ChapterMap.relaxed_title_key("三体"), "三体", "无分隔符不剥离")
+    T.eq(ChapterMap.relaxed_title_key("二、上"), "二、上", "本体过短保留全键")
+    T.eq(ChapterMap.relaxed_title_key("风雪夜归"), "风雪夜归", "无序号原样返回")
+end)
+
+T.case("宽松键匹配救回卷内编号章(A4)", function()
+    -- 本地标题带卷内编号「二、」,微信章名无编号,引文全失配:
+    -- 精确键对不上,宽松键唯一命中救回。
+    local files = {
+        ["c1.xhtml"] = "<html><body><h2>一、春江潮水</h2><p>本地独有正文内容。</p></body></html>",
+        ["c2.xhtml"] = "<html><body><h2>二、月照花林</h2><p>别处不会出现的月光描写段落。</p></body></html>",
+    }
+    local spine = {{href = "c1.xhtml"}, {href = "c2.xhtml"}}
+    local chapters = {{
+        uid = "1", title = "月照花林",
+        underlines = {{range = "0-1", markText = "精校版里不存在的引文甲"},
+                      {range = "1-2", markText = "精校版里不存在的引文乙"}},
+    }}
+    local mapped, unmatched, metrics = ChapterMap.build(spine, function(h) return files[h] end, chapters)
+    T.eq(#mapped, 1, "宽松键救回: unmatched=" .. tostring(#unmatched))
+    T.eq(mapped[1].href, "c2.xhtml", "映射到卷内编号对应的文件")
+    T.eq(mapped[1].quote_only, true, "标题来源强制 quote_only")
+    T.ok(metrics.relaxed_hits >= 1, "记录宽松键命中: " .. tostring(metrics.relaxed_hits))
+end)
+
+T.case("远程重复宽松键时守卫生效(A5)", function()
+    -- 两章微信标题「一、」「二、」宽松后同为「姑娘请自重」→ 远程不唯一 →
+    -- 宽松 tier 整体禁用:本地「三、姑娘请自重」剥号后不得凭宽松键配对。
+    -- (序号不同精确键也不互为子串,标题兜底救不了 → 两章 no_hit。)
+    local files = {
+        ["c1.xhtml"] = "<html><body><h2>三、姑娘请自重</h2><p>正文只有这一句月光如水照佳人。</p></body></html>",
+    }
+    local spine = {{href = "c1.xhtml"}}
+    local chapters = {
+        {uid = "1", title = "一、姑娘请自重",
+         underlines = {{range = "0-1", markText = "精校版里不存在的引文甲"},
+                       {range = "1-2", markText = "精校版里不存在的引文乙"}}},
+        {uid = "2", title = "二、姑娘请自重",
+         underlines = {{range = "0-1", markText = "另一条精校版缺失的引文丙"},
+                       {range = "1-2", markText = "另一条精校版缺失的引文丁"}}},
+    }
+    local mapped, unmatched, metrics = ChapterMap.build(spine, function(h) return files[h] end, chapters)
+    T.eq(#mapped, 0, "远程重复宽松键不产生任何配对")
+    T.eq(metrics.relaxed_hits, 0, "宽松命中计数为 0")
+    T.eq(#unmatched, 2, "两章都无法定案")
+    T.eq(unmatched[1].reason, "no_hit", "走 no_hit 而非错配")
+end)
+
+T.case("精确键优先于宽松键(A6)", function()
+    -- 精确键能命中的块不再消耗宽松命中计数。
+    local files = {
+        ["c1.xhtml"] = "<html><body><h2>一、月照花林</h2><p>滟滟随波千万里。</p></body></html>",
+    }
+    local spine = {{href = "c1.xhtml"}}
+    local chapters = {{
+        uid = "1", title = "一、月照花林",
+        underlines = {{range = "0-8", markText = "滟滟随波千万里"}},
+    }}
+    local mapped, unmatched, metrics = ChapterMap.build(spine, function(h) return files[h] end, chapters)
+    T.eq(#mapped, 1, "精确键命中")
+    T.eq(metrics.relaxed_hits, 0, "精确命中不重复计宽松")
+end)
+
+T.case("序倒挂强制 quote_only(A7)", function()
+    -- 第1章经标题兜底落在后面的文件,第2章引文命中前面的文件 → 倒挂:
+    -- 第2章强制 quote_only 并计数;第1章不受影响。
+    local files = {
+        ["c1.xhtml"] = "<html><body><h2>第二章 别处的月光</h2><p>第二章的正文引文戊己庚辛。</p></body></html>",
+        ["c2.xhtml"] = "<html><body><h2>第一章 春江潮水</h2><p>本地独有的春江正文内容。</p></body></html>",
+    }
+    local spine = {{href = "c1.xhtml"}, {href = "c2.xhtml"}}
+    local chapters = {
+        {uid = "1", title = "第一章 春江潮水",
+         underlines = {{range = "0-1", markText = "精校后不存在的引文甲"},
+                       {range = "1-2", markText = "精校后不存在的引文乙"}}},
+        {uid = "2", title = "第二章 别处的月光",
+         underlines = {{range = "0-8", markText = "第二章的正文引文戊己庚辛"},
+                       {range = "8-9", markText = "第二章的另一句引文辛壬癸甲"}}},
+    }
+    local mapped, unmatched, metrics = ChapterMap.build(spine, function(h) return files[h] end, chapters)
+    T.eq(#unmatched, 0, "两章都有目标: unmatched=" .. tostring(#unmatched))
+    T.eq(metrics.order_inversions, 1, "记录一次序倒挂")
+    local by_uid = {}
+    for _, row in ipairs(mapped) do by_uid[row.chapter_uid] = row end
+    T.ok(by_uid["2"].quote_only, "倒挂章强制 quote_only(原本单目标可走数字兜底)")
+    T.ok(by_uid["1"].quote_only, "标题兜底目标本就 quote_only")
+end)
+
+T.case("合并章跨文件不触发序倒挂(A7 反例)", function()
+    -- 微信合并章横跨 c1/c2(合法非递减),下一章从 c2 起:锚点 max 传递,不误报。
+    -- 注意 uid2 标题「后记」本体不得出现在 c2 正文里,否则标题兜底会以
+    -- quote_only 定案,测不出「单强目标保留数字兜底」的守卫未触发路径。
+    local files = {
+        ["c1.xhtml"] = [[<html><body><p>甲文件专属引文其一。甲文件专属引文其二。</p></body></html>]],
+        ["c2.xhtml"] = [[<html><body><p>乙文件专属引文其一。乙文件专属引文其二。乙文件后半的独有内容甲。乙文件后半的独有内容乙。</p></body></html>]],
+    }
+    local spine = {{href = "c1.xhtml"}, {href = "c2.xhtml"}}
+    local chapters = {
+        {uid = "1", title = "第一章 合并",
+         underlines = {
+            {range = "0-1", markText = "甲文件专属引文其一"},
+            {range = "1-2", markText = "甲文件专属引文其二"},
+            {range = "2-3", markText = "乙文件专属引文其一"},
+            {range = "3-4", markText = "乙文件专属引文其二"}}},
+        {uid = "2", title = "第三章 后记",
+         underlines = {{range = "0-8", markText = "乙文件后半的独有内容甲"},
+                       {range = "8-9", markText = "乙文件后半的独有内容乙"}}},
+    }
+    local mapped, unmatched, metrics = ChapterMap.build(spine, function(h) return files[h] end, chapters)
+    T.eq(#unmatched, 0, "两章均命中")
+    T.eq(metrics.order_inversions, 0, "合法跨文件不记倒挂")
+    local by_uid = {}
+    for _, row in ipairs(mapped) do by_uid[row.chapter_uid] = row end
+    T.eq(by_uid["2"].quote_only, nil, "守卫未触发:单强目标保留数字兜底资格")
+end)
+
+T.case("ALGO_VERSION 升至 9(A8)", function()
+    T.eq(ChapterMap.ALGO_VERSION, 9, "标题键行为变化,旧映射缓存整体作废")
+end)

--- a/tests/test_epub_reader.lua
+++ b/tests/test_epub_reader.lua
@@ -119,6 +119,37 @@ T.case("each_spine 回调取消后停止读取并关闭 Reader", function()
     T.eq(book._reader_new_count, 2, "取消后 Reader 已关闭且没有重复打开")
 end)
 
+T.case("each_spine 透传 all_matched 成功信号(不误报取消)", function()
+    -- 回归:全部章节命中后的提前退出返回 false,"all_matched"——
+    -- 第二返回值曾被丢弃并误报成「已取消」,把完美同步打成失败。
+    local book = fake_book()
+    local meta = EpubReader.load("allmatched.epub", book)
+    local calls = 0
+    local ok, err = EpubReader.each_spine(meta, function()
+        calls = calls + 1
+        return false, "all_matched"
+    end, book)
+    T.eq(ok, false, "提前退出仍返回 false")
+    T.eq(err, "all_matched", "成功信号原样透传,不得变成已取消")
+    T.eq(calls, 1, "信号触发后停止回调")
+end)
+
+T.case("each_spine 缺失 spine 条目路径同样透传 all_matched", function()
+    -- 少一个 spine 实体文件:走「EPUB 中缺少 spine 条目」补偿回调分支。
+    local book = STUBS.archiver_mock({
+        {path = "mimetype", content = "application/epub+zip"},
+        {path = "META-INF/container.xml", content = CONTAINER},
+        {path = "OEBPS/content.opf", content = OPF},
+        {path = "OEBPS/Text/ch 1.xhtml", content = "<html><body>一</body></html>"},
+    })
+    local meta = EpubReader.load("missing.epub", book)
+    local ok, err = EpubReader.each_spine(meta, function()
+        return false, "all_matched"
+    end, book)
+    T.eq(ok, false, "补偿分支同样返回 false")
+    T.eq(err, "all_matched", "all_matched 在缺失条目分支不丢")
+end)
+
 T.case("坏包报错", function()
     local no_container = STUBS.archiver_mock({{path = "mimetype", content = "application/epub+zip"}})
     local meta, err = EpubReader.load("bad.epub", no_container)


### PR DESCRIPTION
## 背景

对照上游 weread PR #150（v1.4.0~v1.4.2 已验证）的成熟实现，补齐撷思章节标题匹配的四处增强。v0.4.0 已落地标题边界有界匹配主框架（ALGO_VERSION 8），本 PR 只移植上游在其之上打磨出的鲁棒性改进。

## 改动内容

1. **宽松标题键（R1）**：剥「二、」「（二）」「2.」卷内序号，只留章名本体参与匹配；带远程唯一性守卫（重名键禁用）。救回「本地标题带卷内编号、微信章名无编号」的章节。新增 `metrics.relaxed_hits`。
2. **更新后缀关键词扩展（R2）**：括号剥离关键词从「更」扩展到 `{更,求,订,阅,票,藏,赏}`。
3. **英文 Chapter 前缀剥离（R3）**：`Chapter 12:` / `CHAPTER XIII -`；序号识别补罗马数字（上游 `is_outline_number` 对齐）。
4. **目标顺序单调守卫（R4）**：后一章目标锚点前移于前一章时强制 `quote_only` 禁数字兜底并计数（`order_inversions`），不删除已命中目标。
5. **ALGO_VERSION 8→9**：旧映射缓存自动作废。

## 真机发现并修复的回归

宽松键上线后首次出现 200/200 全命中，提前退出的成功信号 `"all_matched"` 被 `EpubReader.each_spine` / `cached_read_spine` 丢弃并误报成「同步已取消」（该信号自 v0.4.0 引入从未真正触发过）。已修复全部 5 处信号传递点，`cancelled()` 增加一次性取消文件诊断。

## 测试

- 新增 11 组回归测试（宽松键正反例/唯一性守卫/精确优先/序倒挂正反例/all_matched 透传两条路径/版本契约），Lua **479 passed / 0 failed**，Python 契约全绿，54 个 Lua 文件编译通过
- KPW4 真机验证：两批完整同步（1–200 全中、201–400 边界命中 204 目标），strategy 新指标生效，`all_matched` 修复后零误报，第一批匹配+注入仅 149 秒

## 文档

- 需求/实施/测试用例三份文档在本地 docs/（含真机 B1~B5 验收步骤）
- 明确不移植：协程单步续传（架构不同）、匹配后回读校验（注入阶段天然重对齐）、子进程预取（另行评估）

## 真机验证

- 设备：KPW4，《剑来》1284 个正文文件
- 批次一（1–200）：匹配+注入 149 秒，200/200 命中，注入 1333 条目
- 批次二（201–400）：边界命中 202 文件 204 目标，预算机制正常收尾，零错误